### PR TITLE
Tableau SQL Endpoint: Complete B4 correctness and golden-result testing

### DIFF
--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -1,9 +1,9 @@
 # Skadi — Development Status
 
 > Updated: 2026-05-12
-> Branch: `feature/tableau-sql-endpoint-b3-protocol-completeness` → PR #31
-> Last commit: `0243425`
-> Build: ✅ 118 tests passing
+> Branch: `main` (B4 uncommitted)
+> Last commit: `1583ee8`
+> Build: ✅ 154 tests passing
 
 ---
 
@@ -30,7 +30,7 @@
 | B1 | Auth & authorisation (enterprise-ready) | ✅ Done | `adda9fd` | trust / plaintext / bcrypt + schema ACL |
 | B2 | Cancellation, timeouts, resource controls | ✅ Done | `5c07c1b` | See below |
 | B3 | Protocol completeness for JDBC ecosystem | ✅ Done | `0243425` (PR #31) | L1 fixed: Bind params parsed + forwarded to both execution paths |
-| B4 | Correctness test suite (golden results) | 🔜 Next | — | |
+| B4 | Correctness test suite (golden results) | ✅ Done | pending | 36 tests; 2 bugs fixed in Arrow/path-1 value rendering |
 | B5 | Observability — metrics, tracing, dashboards | ❌ Not started | — | Hit/miss counters only |
 | B6 | Security hardening — TLS, redaction, audit log | ❌ Not started | — | Plaintext credentials on wire |
 | B7 | Tableau Server / Cloud deployment readiness | ❌ Not started | — | Local dev only |
@@ -105,14 +105,47 @@
 
 ---
 
+## B4 Implementation Summary
+
+**Issue:** #26
+**Build:** 154 tests, 0 failures (36 new tests added)
+
+### Bugs fixed
+
+| Bug | File | Detail |
+|---|---|---|
+| Arrow timestamp rendered as epoch millis | `ArrowIpcRowWriter.java` | `TimeStampMilliVector.getObject()` returns `Long`; now rendered via `LocalDateTime.ofInstant(…, ZoneId.systemDefault())` |
+| Arrow date rendered as epoch days | `ArrowIpcRowWriter.java` | `DateDayVector.getObject()` returns `Integer`; now rendered via `LocalDate.ofEpochDay()` |
+| Path 1 timestamp trailing `.0` | `PgWireSession.java` | `Timestamp.toString()` produces `"2021-06-15 12:30:00.0"`; replaced with `renderJdbcValue()` using `Timestamp.toLocalDateTime()` |
+
+### Test classes added
+
+| Class | Tests | What it covers |
+|---|---|---|
+| `ValueEncodingArrowTest` | 8 | Arrow IPC → pgwire text rendering; timestamp, date, decimal, null, bigint |
+| `NullSemanticsTest` | 4 | SQL NULL arrives as Java `null`; `wasNull()` returns true |
+| `DecimalCorrectnessTest` | 5 | Scale preserved; negative sign; zero; small fractional; inline CAST |
+| `TimestampFormattingTest` | 5 | No trailing `.0`; ISO format; epoch-zero renders as date not number |
+| `TypeOidCorrectnessTest` | 8 | OID round-trip: BIGINT→20, INTEGER→23, NUMERIC→1700, DATE→1082, TIMESTAMP→1114, etc. |
+| `OrderingLimitTest` | 6 | ASC/DESC order; LIMIT; LIMIT+OFFSET; string collation |
+
+### Infrastructure
+
+- `GatewayCorrectnessHarness`: shared H2-backed PgWireServer; trust auth; cache disabled; simple-query mode
+- Golden results are inline expected values in each test (not snapshot files)
+- No Databricks connection required — all 154 tests pass in CI
+
+### Note on timezone (Arrow path)
+
+`TIMESTAMP` (no TZ) round-trips through `ZoneId.systemDefault()` — consistent with JDBC's `Timestamp.toLocalDateTime()`. Both paths now produce identical output regardless of JVM timezone offset.
+
+---
+
 ## Next Recommended Issue
 
-**B4 — Correctness test suite (golden results)**
+**B5 — Observability (production-grade metrics)**
 
-B3 is now complete. The next high-value story is B4: a correctness test suite that validates query results against known-good data. This requires:
-1. A seeded test dataset in Databricks (or H2 for unit tests)
-2. Golden-result snapshots for common Tableau query patterns
-3. Integration tests that run the full gateway pipeline and compare results
+B4 is complete. Next: Prometheus/Micrometer counters for cache hit/miss, query latency, active session count, and error rates. Scope: wire `QueryCacheMetrics` and `QueryResultCacheMetrics` into Micrometer; expose via `/actuator/prometheus`.
 
 **Alternative: L14 — Fix Execute/Describe RowDescription duplication**
-Resolving L14 would unlock DBeaver and DataGrip compatibility via extended-query mode, without needing a Databricks connection for test coverage. Scope: track `portalDescribed` flag; skip RowDescription in Execute response when Describe was already answered.
+Scope: track `portalDescribed` flag; skip RowDescription in Execute response when Describe already answered. Unlocks DBeaver/DataGrip extended-query mode.

--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -1,8 +1,8 @@
 # Skadi — Development Status
 
 > Updated: 2026-05-12
-> Branch: `main` (B4 uncommitted)
-> Last commit: `1583ee8`
+> Branch: `feature/tableau-sql-endpoint-b4-correctness-tests` → PR #32
+> Last commit: `ce47076`
 > Build: ✅ 154 tests passing
 
 ---
@@ -30,8 +30,8 @@
 | B1 | Auth & authorisation (enterprise-ready) | ✅ Done | `adda9fd` | trust / plaintext / bcrypt + schema ACL |
 | B2 | Cancellation, timeouts, resource controls | ✅ Done | `5c07c1b` | See below |
 | B3 | Protocol completeness for JDBC ecosystem | ✅ Done | `0243425` (PR #31) | L1 fixed: Bind params parsed + forwarded to both execution paths |
-| B4 | Correctness test suite (golden results) | ✅ Done | pending | 36 tests; 2 bugs fixed in Arrow/path-1 value rendering |
-| B5 | Observability — metrics, tracing, dashboards | ❌ Not started | — | Hit/miss counters only |
+| B4 | Correctness test suite (golden results) | ✅ Done | `ce47076` (PR #32) | 36 tests; 2 bugs fixed in Arrow/path-1 value rendering |
+| B5 | Observability — metrics, tracing, dashboards | 🔜 Next | — | Hit/miss counters only |
 | B6 | Security hardening — TLS, redaction, audit log | ❌ Not started | — | Plaintext credentials on wire |
 | B7 | Tableau Server / Cloud deployment readiness | ❌ Not started | — | Local dev only |
 | B8 | MySQL wire-protocol endpoint (optional) | ❌ Not started | — | Dialect translator exists |
@@ -102,6 +102,9 @@
 | L13 | `ai/query-flow.md` missing | Referenced in `ai/claude-instructions.md`; file does not exist |
 | L14 | Execute sends RowDescription when Describe already did | Extended-query flow: server emits RowDescription in Execute response even after Describe(S/P) was answered. JDBC drivers that send Describe (DBeaver, DataGrip) may see duplicate `T` messages; Tableau (no Describe) is unaffected |
 | L15 | Bind binary-format params not decoded | Binary-format (`fmt=1`) bind params decoded as UTF-8 text with a warning; correct decoding requires type OID dispatch |
+| L16 | `SqlGatewayIT` placeholder still disabled | Real Databricks integration tests need CI secrets and a seeded test warehouse; currently placeholder only |
+| L17 | `TIMESTAMPTZ` Arrow path not tested | `TimeStampMilliTZVector` codepath not exercised; Databricks returns this for `TIMESTAMP WITH TIME ZONE` columns |
+| L18 | `BOOLEAN` wire format is `"true"`/`"false"` | PostgreSQL native protocol uses `"t"`/`"f"`; some strict clients may reject the lowercase word form |
 
 ---
 
@@ -145,7 +148,21 @@
 
 **B5 — Observability (production-grade metrics)**
 
-B4 is complete. Next: Prometheus/Micrometer counters for cache hit/miss, query latency, active session count, and error rates. Scope: wire `QueryCacheMetrics` and `QueryResultCacheMetrics` into Micrometer; expose via `/actuator/prometheus`.
+B4 is complete. B5 scope:
+- Wire `QueryCacheMetrics` and `QueryResultCacheMetrics` into Micrometer
+- Add counters: cache hit/miss, query latency histogram, active session gauge, error rate by SQLSTATE
+- Expose via `/actuator/prometheus` (Spring Boot Actuator already present)
+- No new architecture — instrument existing counters, add Micrometer dependency
 
 **Alternative: L14 — Fix Execute/Describe RowDescription duplication**
-Scope: track `portalDescribed` flag; skip RowDescription in Execute response when Describe already answered. Unlocks DBeaver/DataGrip extended-query mode.
+Scope: track `portalDescribed` flag; skip RowDescription in Execute when Describe already answered. Unlocks DBeaver/DataGrip extended-query compatibility.
+
+---
+
+## Technical Debt Discovered During B4
+
+| ID | Detail | Priority |
+|---|---|---|
+| L16 | `SqlGatewayIT` placeholder — real Databricks integration tests need CI secrets + seeded warehouse | Low (blocks live data validation only) |
+| L17 | `TIMESTAMPTZ` Arrow path untested — `TimeStampMilliTZVector` not exercised by H2 (H2 has no `TIMESTAMP WITH TIME ZONE` that round-trips via Arrow TZ vector) | Medium (Databricks `timestamp_ltz` columns) |
+| L18 | `BOOLEAN` renders as `"true"`/`"false"` — PostgreSQL native uses `"t"`/`"f"`; `JdbcToPgTypeMapper` maps BOOL→OID 16 correctly but value encoding diverges | Low (most clients accept both forms) |

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/pgwire/ArrowIpcRowWriter.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/pgwire/ArrowIpcRowWriter.java
@@ -2,7 +2,9 @@ package org.iceforge.skadi.sqlgateway.pgwire;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -13,6 +15,11 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -55,7 +62,7 @@ final class ArrowIpcRowWriter {
                     String[] row = new String[fields.size()];
                     for (int c = 0; c < fields.size(); c++) {
                         FieldVector v = root.getVector(c);
-                        row[c] = v.isNull(r) ? null : formatValue(v.getObject(r));
+                        row[c] = v.isNull(r) ? null : formatValue(v, r);
                     }
                     PgRowWriter.writeDataRow(out, row);
                     rowCount++;
@@ -74,10 +81,27 @@ final class ArrowIpcRowWriter {
         }
     }
 
-    private static String formatValue(Object val) {
-        if (val == null) return null;
-        // Arrow Text wraps bytes; toString() returns the string correctly.
-        return val.toString();
+    private static final DateTimeFormatter TIMESTAMP_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * Renders an Arrow vector slot as a pgwire text-format string.
+     *
+     * <p>Timestamps and dates need special treatment: Arrow stores them as epoch millis /
+     * epoch days (integers) and {@code getObject().toString()} would produce a raw number.
+     */
+    private static String formatValue(FieldVector v, int r) {
+        if (v instanceof TimeStampMilliVector ts) {
+            // TIMESTAMP (no TZ) round-trips through the JVM default zone, consistent
+            // with JDBC Timestamp.toLocalDateTime() used on path 1.
+            return LocalDateTime.ofInstant(Instant.ofEpochMilli(ts.get(r)), ZoneId.systemDefault())
+                    .format(TIMESTAMP_FMT);
+        }
+        if (v instanceof DateDayVector d) {
+            return LocalDate.ofEpochDay(d.get(r)).toString(); // "yyyy-MM-dd"
+        }
+        Object obj = v.getObject(r);
+        return obj == null ? null : obj.toString();
     }
 
     private static void writeEmptyRowDescription(DataOutputStream out) throws IOException {

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/pgwire/PgWireSession.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/pgwire/PgWireSession.java
@@ -35,8 +35,10 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -670,8 +672,7 @@ final class PgWireSession implements Runnable {
                     while (rs.next()) {
                         String[] row = new String[colCount];
                         for (int i = 1; i <= colCount; i++) {
-                            Object v = rs.getObject(i);
-                            row[i - 1] = (v == null) ? null : v.toString();
+                            row[i - 1] = renderJdbcValue(rs.getObject(i));
                         }
                         PgRowWriter.writeDataRow(out, row);
                         rows++;
@@ -700,14 +701,30 @@ final class PgWireSession implements Runnable {
         while (rs.next()) {
             String[] row = new String[colCount];
             for (int i = 1; i <= colCount; i++) {
-                Object v = rs.getObject(i);
-                row[i - 1] = (v == null) ? null : v.toString();
+                row[i - 1] = renderJdbcValue(rs.getObject(i));
             }
             PgRowWriter.writeDataRow(out, row);
             rows++;
             if (rows % flushEvery == 0) out.flush();
         }
         return rows;
+    }
+
+    private static final DateTimeFormatter TIMESTAMP_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * Renders a JDBC value as a pgwire text-format string.
+     *
+     * <p>{@link Timestamp#toString()} appends trailing ".0" for whole-second values;
+     * rendering via LocalDateTime avoids that and produces a consistent ISO-like format.
+     */
+    static String renderJdbcValue(Object v) {
+        if (v == null) return null;
+        if (v instanceof Timestamp ts) {
+            return ts.toLocalDateTime().format(TIMESTAMP_FMT);
+        }
+        return v.toString();
     }
 
     private void applyConnectionContext(Connection conn) {

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/DecimalCorrectnessTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/DecimalCorrectnessTest.java
@@ -1,0 +1,94 @@
+package org.iceforge.skadi.sqlgateway.pgwire;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B4 — Decimal scale and value correctness.
+ *
+ * <p>Tableau uses NUMERIC/DECIMAL column values for measure aggregation. The wire
+ * representation must preserve declared scale so clients parse the right magnitude.
+ */
+class DecimalCorrectnessTest {
+
+    private GatewayCorrectnessHarness harness;
+
+    @BeforeEach
+    void start() throws Exception {
+        harness = new GatewayCorrectnessHarness();
+    }
+
+    @AfterEach
+    void stop() {
+        harness.close();
+    }
+
+    @Test
+    void scale_preserved_for_positive_value() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT val FROM skadi_decimals WHERE label = 'positive'")) {
+            assertThat(rs.next()).isTrue();
+            BigDecimal v = rs.getBigDecimal("val");
+            // 1234.5600 stored with scale=4; wire value must not lose or gain digits
+            assertThat(v.toPlainString()).isEqualTo("1234.5600");
+        }
+    }
+
+    @Test
+    void negative_decimal_sign_preserved() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT val FROM skadi_decimals WHERE label = 'negative'")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getBigDecimal("val").signum()).isNegative();
+            assertThat(rs.getString("val")).startsWith("-");
+        }
+    }
+
+    @Test
+    void zero_decimal_renders_without_sign_error() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT val FROM skadi_decimals WHERE label = 'zero'")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getBigDecimal("val").compareTo(BigDecimal.ZERO)).isZero();
+        }
+    }
+
+    @Test
+    void small_fractional_value_not_truncated() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT val FROM skadi_decimals WHERE label = 'small'")) {
+            assertThat(rs.next()).isTrue();
+            BigDecimal v = rs.getBigDecimal("val");
+            assertThat(v.compareTo(new BigDecimal("0.0001"))).isZero();
+        }
+    }
+
+    @Test
+    void inline_decimal_cast_scale_preserved() throws Exception {
+        // Inline CAST — exercises the type OID path with no table involved.
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT CAST(99.90 AS DECIMAL(8,2)) AS v")) {
+            assertThat(rs.next()).isTrue();
+            // String representation via JDBC BigDecimal should be "99.90"
+            assertThat(rs.getBigDecimal("v").toPlainString()).isEqualTo("99.90");
+        }
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/GatewayCorrectnessHarness.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/GatewayCorrectnessHarness.java
@@ -1,0 +1,137 @@
+package org.iceforge.skadi.sqlgateway.pgwire;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.iceforge.skadi.sqlgateway.config.SqlGatewayProperties;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Map;
+
+/**
+ * Shared test harness for B4 correctness tests.
+ *
+ * <p>Starts a PgWireServer backed by an in-memory H2 database seeded with representative
+ * data for every JDBC type the gateway must handle. Tests connect to the gateway via the
+ * standard PostgreSQL JDBC driver in simple-query mode to avoid L14 (duplicate
+ * RowDescription) and exercise path 1 (JDBC text rows).
+ *
+ * <p>Arrow path (path 3) is covered separately in {@link ValueEncodingArrowTest}.
+ *
+ * <p>Usage: create in @BeforeEach, close in @AfterEach.
+ */
+final class GatewayCorrectnessHarness implements AutoCloseable {
+
+    static final String H2_URL = "jdbc:h2:mem:skadi_correctness;DB_CLOSE_DELAY=-1";
+
+    static {
+        seedH2();
+    }
+
+    private final PgWireServer server;
+
+    GatewayCorrectnessHarness() throws Exception {
+        JdbcDataSource h2 = new JdbcDataSource();
+        h2.setURL(H2_URL);
+
+        // Inject H2 as the executor; PgWireSession picks this up via SqlExecutorProviderHolder.
+        SqlExecutorProviderHolder.set(h2::getConnection);
+
+        SqlGatewayProperties.PgWire.Auth auth =
+                new SqlGatewayProperties.PgWire.Auth("trust", null, Map.of(), null);
+        // cacheProps = null → caching disabled; tests always hit H2.
+        SqlGatewayProperties.PgWire props =
+                new SqlGatewayProperties.PgWire(true, "127.0.0.1", 0, auth, null, null, null, null);
+
+        this.server = new PgWireServer(props, null, null, null);
+        server.start();
+        for (int i = 0; i < 50 && server.getLocalPort() == 0; i++) Thread.sleep(10);
+    }
+
+    /** Returns a JDBC connection to the gateway in simple-query mode. */
+    Connection jdbcClient() throws Exception {
+        Class.forName("org.postgresql.Driver");
+        String url = "jdbc:postgresql://127.0.0.1:" + server.getLocalPort()
+                + "/postgres?ssl=false&preferQueryMode=simple&socketTimeout=10";
+        return DriverManager.getConnection(url, "testuser", "");
+    }
+
+    @Override
+    public void close() {
+        SqlExecutorProviderHolder.set(null);
+        server.close();
+    }
+
+    // --- Seed tables ---
+
+    private static void seedH2() {
+        try {
+            JdbcDataSource ds = new JdbcDataSource();
+            ds.setURL(H2_URL);
+            try (Connection c = ds.getConnection(); Statement st = c.createStatement()) {
+
+                // Main type-coverage table.
+                st.execute("DROP TABLE IF EXISTS skadi_types");
+                st.execute("""
+                    CREATE TABLE skadi_types (
+                        id_col      BIGINT,
+                        int_col     INTEGER,
+                        small_col   SMALLINT,
+                        double_col  DOUBLE PRECISION,
+                        dec_col     DECIMAL(10,2),
+                        bool_col    BOOLEAN,
+                        str_col     VARCHAR(100),
+                        date_col    DATE,
+                        ts_col      TIMESTAMP,
+                        null_col    VARCHAR(10)
+                    )
+                """);
+                st.execute("""
+                    INSERT INTO skadi_types VALUES (
+                        9000000000001,
+                        42,
+                        7,
+                        3.14159,
+                        1234.56,
+                        TRUE,
+                        'hello world',
+                        '2021-06-15',
+                        '2021-06-15 12:30:00',
+                        NULL
+                    )
+                """);
+
+                // Additional decimal edge cases.
+                st.execute("DROP TABLE IF EXISTS skadi_decimals");
+                st.execute("CREATE TABLE skadi_decimals (label VARCHAR(20), val DECIMAL(12,4))");
+                st.execute("""
+                    INSERT INTO skadi_decimals VALUES
+                        ('zero',      0.0000),
+                        ('positive',  1234.5600),
+                        ('negative', -9.7500),
+                        ('small',     0.0001)
+                """);
+
+                // Ordering test table.
+                st.execute("DROP TABLE IF EXISTS skadi_orders");
+                st.execute("CREATE TABLE skadi_orders (n INTEGER, label VARCHAR(10))");
+                st.execute("""
+                    INSERT INTO skadi_orders VALUES
+                        (3,'c'),(1,'a'),(2,'b'),(4,'d'),(5,'e')
+                """);
+
+                // Null-heavy table.
+                st.execute("DROP TABLE IF EXISTS skadi_nulls");
+                st.execute("CREATE TABLE skadi_nulls (id INTEGER, val VARCHAR(20), num DECIMAL(8,2))");
+                st.execute("""
+                    INSERT INTO skadi_nulls VALUES
+                        (1, NULL, NULL),
+                        (2, 'present', 1.23),
+                        (3, NULL, 4.56)
+                """);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("H2 seed failed", e);
+        }
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/NullSemanticsTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/NullSemanticsTest.java
@@ -1,0 +1,81 @@
+package org.iceforge.skadi.sqlgateway.pgwire;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B4 — Null semantics: SQL NULL must arrive as Java {@code null} at the JDBC client,
+ * not as the string {@code "null"} or an empty string.
+ *
+ * <p>Verifies pgwire length=-1 encoding for nulls in both varchar and numeric columns.
+ */
+class NullSemanticsTest {
+
+    private GatewayCorrectnessHarness harness;
+
+    @BeforeEach
+    void start() throws Exception {
+        harness = new GatewayCorrectnessHarness();
+    }
+
+    @AfterEach
+    void stop() {
+        harness.close();
+    }
+
+    @Test
+    void varchar_null_arrives_as_java_null() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT val FROM skadi_nulls WHERE id = 1")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("val")).isNull();
+            assertThat(rs.wasNull()).isTrue();
+        }
+    }
+
+    @Test
+    void numeric_null_arrives_as_java_null() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT num FROM skadi_nulls WHERE id = 1")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getObject("num")).isNull();
+            assertThat(rs.wasNull()).isTrue();
+        }
+    }
+
+    @Test
+    void non_null_column_is_not_null() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT val, num FROM skadi_nulls WHERE id = 2")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("val")).isEqualTo("present");
+            assertThat(rs.wasNull()).isFalse();
+            assertThat(rs.getBigDecimal("num")).isNotNull();
+        }
+    }
+
+    @Test
+    void null_in_typed_column_from_main_table() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT null_col FROM skadi_types")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("null_col")).isNull();
+            assertThat(rs.wasNull()).isTrue();
+        }
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/OrderingLimitTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/OrderingLimitTest.java
@@ -1,0 +1,97 @@
+package org.iceforge.skadi.sqlgateway.pgwire;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B4 — ORDER BY, LIMIT, and OFFSET correctness.
+ *
+ * <p>Tableau issues queries with ORDER BY + LIMIT to fetch sorted previews.
+ * These tests verify that the gateway forwards ordering and cardinality constraints
+ * faithfully to the backend and returns results in the declared order.
+ */
+class OrderingLimitTest {
+
+    private GatewayCorrectnessHarness harness;
+
+    @BeforeEach
+    void start() throws Exception {
+        harness = new GatewayCorrectnessHarness();
+    }
+
+    @AfterEach
+    void stop() {
+        harness.close();
+    }
+
+    @Test
+    void order_by_asc_returns_sorted_rows() throws Exception {
+        List<Integer> values = queryInts("SELECT n FROM skadi_orders ORDER BY n ASC");
+        assertThat(values).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void order_by_desc_returns_reverse_sorted_rows() throws Exception {
+        List<Integer> values = queryInts("SELECT n FROM skadi_orders ORDER BY n DESC");
+        assertThat(values).containsExactly(5, 4, 3, 2, 1);
+    }
+
+    @Test
+    void limit_restricts_row_count() throws Exception {
+        List<Integer> values = queryInts("SELECT n FROM skadi_orders ORDER BY n ASC LIMIT 3");
+        assertThat(values).hasSize(3);
+        assertThat(values).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void limit_with_offset_skips_leading_rows() throws Exception {
+        List<Integer> values = queryInts(
+                "SELECT n FROM skadi_orders ORDER BY n ASC LIMIT 2 OFFSET 2");
+        assertThat(values).containsExactly(3, 4);
+    }
+
+    @Test
+    void order_by_string_column_is_lexicographic() throws Exception {
+        List<String> labels = queryStrings(
+                "SELECT label FROM skadi_orders ORDER BY label ASC");
+        assertThat(labels).containsExactly("a", "b", "c", "d", "e");
+    }
+
+    @Test
+    void limit_1_returns_exactly_one_row() throws Exception {
+        List<Integer> values = queryInts(
+                "SELECT n FROM skadi_orders ORDER BY n ASC LIMIT 1");
+        assertThat(values).hasSize(1).containsExactly(1);
+    }
+
+    // --- helpers ---
+
+    private List<Integer> queryInts(String sql) throws Exception {
+        List<Integer> result = new ArrayList<>();
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) result.add(rs.getInt(1));
+        }
+        return result;
+    }
+
+    private List<String> queryStrings(String sql) throws Exception {
+        List<String> result = new ArrayList<>();
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) result.add(rs.getString(1));
+        }
+        return result;
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/TimestampFormattingTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/TimestampFormattingTest.java
@@ -1,0 +1,100 @@
+package org.iceforge.skadi.sqlgateway.pgwire;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B4 — Timestamp and date wire-format correctness.
+ *
+ * <p>Guarded regressions:
+ * <ul>
+ *   <li>Timestamps must arrive as {@code "yyyy-MM-dd HH:mm:ss"}, not as a raw
+ *       epoch-millisecond integer or as {@code "yyyy-MM-dd HH:mm:ss.0"} (trailing ".0"
+ *       from {@link java.sql.Timestamp#toString()}).</li>
+ *   <li>Dates must arrive as {@code "yyyy-MM-dd"}.</li>
+ *   <li>UTC baseline: the gateway reports {@code TimeZone=UTC}; timestamps stored without
+ *       time-zone info are transmitted as-is.</li>
+ * </ul>
+ */
+class TimestampFormattingTest {
+
+    private GatewayCorrectnessHarness harness;
+
+    @BeforeEach
+    void start() throws Exception {
+        harness = new GatewayCorrectnessHarness();
+    }
+
+    @AfterEach
+    void stop() {
+        harness.close();
+    }
+
+    @Test
+    void timestamp_no_trailing_dot_zero() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery("SELECT ts_col FROM skadi_types")) {
+            assertThat(rs.next()).isTrue();
+            String raw = rs.getString("ts_col");
+            // Must not end with ".0" — that is Timestamp.toString() artifact
+            assertThat(raw).doesNotEndWith(".0");
+            assertThat(raw).doesNotEndWith(".000");
+        }
+    }
+
+    @Test
+    void timestamp_format_is_iso_like() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery("SELECT ts_col FROM skadi_types")) {
+            assertThat(rs.next()).isTrue();
+            String raw = rs.getString("ts_col");
+            // Expected: "2021-06-15 12:30:00"
+            assertThat(raw).isEqualTo("2021-06-15 12:30:00");
+        }
+    }
+
+    @Test
+    void date_format_is_iso() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery("SELECT date_col FROM skadi_types")) {
+            assertThat(rs.next()).isTrue();
+            String raw = rs.getString("date_col");
+            assertThat(raw).isEqualTo("2021-06-15");
+        }
+    }
+
+    @Test
+    void epoch_unix_timestamp_renders_as_date_not_number() throws Exception {
+        // 1970-01-01 00:00:00 — epoch zero; must not come back as "0" or "0.0"
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT TIMESTAMP '1970-01-01 00:00:00' AS epoch_ts")) {
+            assertThat(rs.next()).isTrue();
+            String raw = rs.getString("epoch_ts");
+            assertThat(raw).isEqualTo("1970-01-01 00:00:00");
+        }
+    }
+
+    @Test
+    void epoch_zero_date_renders_as_date_not_number() throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT DATE '1970-01-01' AS epoch_d")) {
+            assertThat(rs.next()).isTrue();
+            String raw = rs.getString("epoch_d");
+            assertThat(raw).isEqualTo("1970-01-01");
+        }
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/TypeOidCorrectnessTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/TypeOidCorrectnessTest.java
@@ -1,0 +1,95 @@
+package org.iceforge.skadi.sqlgateway.pgwire;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.sql.Types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B4 — PostgreSQL OID round-trip correctness.
+ *
+ * <p>The gateway sets OIDs in RowDescription via {@link JdbcToPgTypeMapper}. The
+ * PostgreSQL JDBC driver on the client side maps those OIDs back to JDBC types.
+ * This test asserts the full round-trip: H2 JDBC type → PG OID (in RowDescription) →
+ * JDBC type reported by the client driver.
+ *
+ * <p>Correct OIDs matter because Tableau uses them to classify columns as measures
+ * (numeric OIDs) or dimensions (text/date OIDs).
+ */
+class TypeOidCorrectnessTest {
+
+    private GatewayCorrectnessHarness harness;
+    private ResultSetMetaData meta;
+
+    @BeforeEach
+    void start() throws Exception {
+        harness = new GatewayCorrectnessHarness();
+    }
+
+    @AfterEach
+    void stop() {
+        harness.close();
+    }
+
+    @Test
+    void bigint_oid_roundtrip() throws Exception {
+        assertColumnType("SELECT id_col FROM skadi_types", 1, Types.BIGINT);
+    }
+
+    @Test
+    void integer_oid_roundtrip() throws Exception {
+        assertColumnType("SELECT int_col FROM skadi_types", 1, Types.INTEGER);
+    }
+
+    @Test
+    void smallint_oid_roundtrip() throws Exception {
+        assertColumnType("SELECT small_col FROM skadi_types", 1, Types.SMALLINT);
+    }
+
+    @Test
+    void double_oid_roundtrip() throws Exception {
+        assertColumnType("SELECT double_col FROM skadi_types", 1, Types.DOUBLE);
+    }
+
+    @Test
+    void numeric_oid_roundtrip() throws Exception {
+        // PG OID 1700 (NUMERIC) → JDBC driver maps to Types.NUMERIC
+        assertColumnType("SELECT dec_col FROM skadi_types", 1, Types.NUMERIC);
+    }
+
+    @Test
+    void varchar_oid_roundtrip() throws Exception {
+        assertColumnType("SELECT str_col FROM skadi_types", 1, Types.VARCHAR);
+    }
+
+    @Test
+    void date_oid_roundtrip() throws Exception {
+        assertColumnType("SELECT date_col FROM skadi_types", 1, Types.DATE);
+    }
+
+    @Test
+    void timestamp_oid_roundtrip() throws Exception {
+        assertColumnType("SELECT ts_col FROM skadi_types", 1, Types.TIMESTAMP);
+    }
+
+    // --- helper ---
+
+    private void assertColumnType(String sql, int col, int expectedJdbcType) throws Exception {
+        try (Connection c = harness.jdbcClient();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(sql)) {
+            ResultSetMetaData md = rs.getMetaData();
+            int actualType = md.getColumnType(col);
+            assertThat(actualType)
+                    .as("JDBC type for column %d of [%s]", col, sql)
+                    .isEqualTo(expectedJdbcType);
+        }
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/ValueEncodingArrowTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/ValueEncodingArrowTest.java
@@ -1,0 +1,160 @@
+package org.iceforge.skadi.sqlgateway.pgwire;
+
+import org.apache.arrow.memory.RootAllocator;
+import org.h2.jdbcx.JdbcDataSource;
+import org.iceforge.skadi.arrow.JdbcArrowStreamer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B4 — Verifies that {@link ArrowIpcRowWriter} renders each JDBC/Arrow type as the correct
+ * pgwire text-format string.
+ *
+ * <p>Key regressions guarded:
+ * <ul>
+ *   <li>Timestamps must be {@code "yyyy-MM-dd HH:mm:ss"}, not epoch milliseconds.</li>
+ *   <li>Dates must be {@code "yyyy-MM-dd"}, not epoch days.</li>
+ *   <li>Decimals must preserve declared scale ({@code "1234.56"} not {@code "1234.5600"}).</li>
+ *   <li>SQL NULL must produce a Java {@code null} value, not the string {@code "null"}.</li>
+ * </ul>
+ */
+class ValueEncodingArrowTest {
+
+    private static JdbcDataSource ds;
+
+    @BeforeAll
+    static void setup() {
+        ds = new JdbcDataSource();
+        ds.setURL(GatewayCorrectnessHarness.H2_URL);
+    }
+
+    @Test
+    void timestamp_rendered_as_iso_not_epoch_millis() throws Exception {
+        List<List<String>> rows = queryRows("SELECT TIMESTAMP '2021-06-15 12:30:00' AS ts");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get(0)).isEqualTo("2021-06-15 12:30:00");
+    }
+
+    @Test
+    void date_rendered_as_iso_not_epoch_days() throws Exception {
+        List<List<String>> rows = queryRows("SELECT DATE '2021-06-15' AS d");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get(0)).isEqualTo("2021-06-15");
+    }
+
+    @Test
+    void decimal_scale_preserved() throws Exception {
+        List<List<String>> rows = queryRows("SELECT CAST(1234.56 AS DECIMAL(10,2)) AS d");
+        assertThat(rows).hasSize(1);
+        // Must be "1234.56" — not "1234.5600" or "1234.6"
+        assertThat(rows.get(0).get(0)).isEqualTo("1234.56");
+    }
+
+    @Test
+    void integer_renders_correctly() throws Exception {
+        List<List<String>> rows = queryRows("SELECT CAST(42 AS INTEGER) AS n");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get(0)).isEqualTo("42");
+    }
+
+    @Test
+    void bigint_renders_correctly() throws Exception {
+        List<List<String>> rows = queryRows("SELECT CAST(9000000000001 AS BIGINT) AS n");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get(0)).isEqualTo("9000000000001");
+    }
+
+    @Test
+    void boolean_renders_as_true_false() throws Exception {
+        List<List<String>> rows = queryRows("SELECT TRUE AS b");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get(0)).isIn("true", "TRUE", "1"); // Arrow BitVector → "true"
+    }
+
+    @Test
+    void null_value_is_null_not_string_null() throws Exception {
+        // Seed H2 table is already created; use a direct literal.
+        List<List<String>> rows = queryRows("SELECT CAST(NULL AS VARCHAR) AS v");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get(0)).isNull();
+    }
+
+    @Test
+    void multi_row_count_matches() throws Exception {
+        List<List<String>> rows = queryRows(
+                "SELECT n FROM skadi_orders ORDER BY n");
+        assertThat(rows).hasSize(5);
+        assertThat(rows.get(0).get(0)).isEqualTo("1");
+        assertThat(rows.get(4).get(0)).isEqualTo("5");
+    }
+
+    // --- helpers ---
+
+    private List<List<String>> queryRows(String sql) throws Exception {
+        byte[] arrowIpc = queryToArrow(sql);
+        ByteArrayOutputStream pgBuf = new ByteArrayOutputStream();
+        ArrowIpcRowWriter.writeRows(arrowIpc, new DataOutputStream(pgBuf));
+        return parsePgwireDataRows(pgBuf.toByteArray());
+    }
+
+    private byte[] queryToArrow(String sql) throws Exception {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        try (Connection conn = ds.getConnection()) {
+            try (var allocator = new RootAllocator()) {
+                JdbcArrowStreamer.stream(conn, sql, 0, 1024, allocator, buf);
+            }
+        }
+        return buf.toByteArray();
+    }
+
+    /**
+     * Minimal pgwire response parser: extracts DataRow ('D') string values.
+     * Skips RowDescription ('T') and stops at the first non-D/T byte.
+     */
+    static List<List<String>> parsePgwireDataRows(byte[] pgwireBytes) {
+        List<List<String>> result = new ArrayList<>();
+        ByteBuffer buf = ByteBuffer.wrap(pgwireBytes).order(ByteOrder.BIG_ENDIAN);
+
+        while (buf.hasRemaining()) {
+            byte msgType = buf.get();
+            int msgLen = buf.getInt(); // includes the 4-byte length itself
+            int bodyLen = msgLen - 4;
+
+            if (msgType == 'T') {
+                // RowDescription — skip
+                buf.position(buf.position() + bodyLen);
+            } else if (msgType == 'D') {
+                // DataRow
+                short numFields = buf.getShort();
+                List<String> row = new ArrayList<>(numFields);
+                for (int i = 0; i < numFields; i++) {
+                    int fieldLen = buf.getInt();
+                    if (fieldLen == -1) {
+                        row.add(null);
+                    } else {
+                        byte[] bytes = new byte[fieldLen];
+                        buf.get(bytes);
+                        row.add(new String(bytes, StandardCharsets.UTF_8));
+                    }
+                }
+                result.add(row);
+            } else {
+                // CommandComplete or anything else — done
+                break;
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

- Added correctness test coverage for SQL endpoint behavior across all accepted types
- Fixed two silent value-rendering bugs uncovered by the new tests
- Added golden-result comparison framework (inline expected values, H2-backed, no Databricks needed)
- Expanded integration and edge-case validation to 154 total tests (36 new)

## Bugs Fixed

| Bug | Location | Impact |
|---|---|---|
| Arrow timestamps rendered as epoch millis (e.g. `1623757800000`) | `ArrowIpcRowWriter.formatValue()` | Tableau/BI tools would receive a raw integer instead of a datetime string |
| Arrow dates rendered as epoch days (e.g. `18793`) | `ArrowIpcRowWriter.formatValue()` | Same issue for date columns on Arrow path |
| Path-1 timestamps include trailing `.0` (e.g. `"2021-06-15 12:30:00.0"`) | `PgWireSession.streamRows()` and path-1b loop | Inconsistent with PostgreSQL wire format; clients may fail to parse |

Root cause for Arrow bugs: `TimeStampMilliVector.getObject()` returns `Long`, `DateDayVector.getObject()` returns `Integer` — calling `.toString()` on these produces the raw numeric representation. Fixed with type-aware dispatch in `formatValue(FieldVector, int)`.

Root cause for path-1 trailing `.0`: `java.sql.Timestamp.toString()` appends `.0` for whole-second values. Fixed with `renderJdbcValue()` helper using `Timestamp.toLocalDateTime()`, consistent with the Arrow path.

**Timezone consistency:** Both paths now use `ZoneId.systemDefault()` for `TIMESTAMP` (no TZ) columns, matching JDBC's `Timestamp.toLocalDateTime()` semantics regardless of JVM timezone.

## Coverage Added

| Test Class | Tests | What it covers |
|---|---|---|
| `ValueEncodingArrowTest` | 8 | Arrow IPC → pgwire text rendering per type (timestamp, date, decimal, null, bigint, multi-row) |
| `NullSemanticsTest` | 4 | SQL NULL → pgwire length=-1 → Java `null`; `wasNull()` returns true |
| `DecimalCorrectnessTest` | 5 | Scale preserved; negative sign; zero; small fractional; inline CAST |
| `TimestampFormattingTest` | 5 | No trailing `.0`; ISO format; epoch-zero edge case |
| `TypeOidCorrectnessTest` | 8 | OID round-trip: BIGINT→20, INTEGER→23, NUMERIC→1700, DATE→1082, TIMESTAMP→1114 via JDBC `ResultSetMetaData` |
| `OrderingLimitTest` | 6 | ASC/DESC ordering; LIMIT; LIMIT+OFFSET; string collation; LIMIT 1 |

Golden-result strategy: inline expected values in each test against H2-seeded tables. No snapshot files — values are compact and reviewable inline.

## Validation

```bash
./mvnw test -pl skadi-sql-gateway
# Tests run: 154, Failures: 0, Errors: 0
```

- All 36 new tests pass
- All 118 pre-existing tests continue to pass
- No Databricks connection required — H2 in-process for all correctness tests
- Integration test placeholder (`SqlGatewayIT`) still disabled; to be activated when Databricks test credentials are wired into CI

## Notes

- No architectural redesign introduced
- Existing protocol/execution/cache separation preserved
- `GatewayCorrectnessHarness` is package-private in `pgwire` test package, giving access to `SqlExecutorProviderHolder` without reflection
- `SqlExecutorProviderHolder` is reset to `null` in harness `close()` to prevent test pollution
- `BOOLEAN` OID not included in `TypeOidCorrectnessTest` — H2 reports `Types.BIT` (-7) for `BOOLEAN` columns, PostgreSQL JDBC maps OID 16 (bool) to `Types.BIT`; this is spec-correct but may be added explicitly in a follow-up

## Technical Debt Discovered

| ID | Area | Detail |
|---|---|---|
| L16 | `SqlGatewayIT` placeholder | Still `@Disabled`; real Databricks integration tests need CI secrets and a seeded test warehouse |
| L17 | Arrow `TIMESTAMPTZ` not tested | `TimeStampMilliTZVector` path not exercised; Databricks returns this for `TIMESTAMP WITH TIME ZONE` columns |
| L18 | Path-1 `BOOLEAN` wire format | H2 renders `Boolean.toString()` as `"true"`/`"false"` (lowercase); some clients may expect `"t"`/`"f"` (PostgreSQL native) |

Closes #26