### PR TITLE
Tableau SQL Endpoint: Complete B7 Tableau Server/Cloud deployment readiness

### DIFF
--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -1,9 +1,9 @@
 # Skadi — Development Status
 
 > Updated: 2026-05-12
-> Branch: `feature/tableau-sql-endpoint-b6-security-hardening` → PR #34
-> Last commit: `287740e`
-> Build: ✅ 199 tests passing
+> Branch: `feature/tableau-sql-endpoint-b7-deployment-readiness` → PR #35
+> Last commit: pending push
+> Build: ✅ 201 tests passing
 
 ---
 
@@ -33,8 +33,41 @@
 | B4 | Correctness test suite (golden results) | ✅ Done | `ce47076` (PR #32) | 36 tests; 2 bugs fixed in Arrow/path-1 value rendering |
 | B5 | Observability — production-grade | ✅ Done | `d2c7f7a` (PR #33) | Prometheus endpoint, Micrometer timers, session gauge, correlation IDs |
 | B6 | Security hardening — TLS, redaction, audit log | ✅ Done | `287740e` (PR #34) | SecretRedactor, SqlSecurityValidator, AuditLog, require-ssl enforcement |
-| B7 | Tableau Server / Cloud deployment readiness | 🔜 Next | — | Local dev only |
+| B7 | Tableau Server / Cloud deployment readiness | ✅ Done | pending (PR #35) | Dockerfile, docker-compose, health indicator, full deployment docs |
 | B8 | MySQL wire-protocol endpoint (optional) | ❌ Not started | — | Dialect translator exists |
+
+---
+
+## B7 Implementation Summary
+
+**Issue:** #35 (to be closed)
+
+### PgWireHealthIndicator
+- `@Component("pgWire")` registered under `pgWire` key for `/actuator/health/pgWire`
+- `@ConditionalOnProperty(prefix = "skadi.sql-gateway.pgwire", name = "enabled", havingValue = "true")`
+- Reports `UP` with `port` and `protocol` details when `PgWireServerLifecycle` is running
+- Reports `DOWN` with `reason` when disabled or not yet bound
+- 2 unit tests: UP path (real server on ephemeral port), DOWN path (disabled lifecycle)
+
+### Docker packaging
+- `skadi-sql-gateway/Dockerfile`: multi-stage build (eclipse-temurin:21-jdk-jammy → 21-jre-jammy)
+- Non-root `skadi` system user; EXPOSE 15432 and 8090; HEALTHCHECK on `/actuator/health`
+- Note: Databricks JDBC driver excluded (provided/optional scope) — extend image or mount volume
+- `skadi-sql-gateway/docker-compose.yml`: full env-var mapping with sensible defaults; Prometheus/Grafana commented
+
+### Deployment documentation
+- `docs/deployment/README.md`: architecture overview, port table, full config reference table, health endpoint table
+- `docs/deployment/docker.md`: build, compose, docker run, JDBC driver options, TLS proxy examples, k8s manifest with readiness probe on `/actuator/health/pgWire`
+- `docs/deployment/tableau-server.md`: Tableau Desktop connect walkthrough, publish data source, schedule refresh, SSL, supported features
+- `docs/deployment/tableau-bridge.md`: Bridge architecture, install walkthrough, live vs extract modes, firewall requirements, sizing guide
+- `docs/deployment/production-checklist.md`: infrastructure, configuration, security, health check, smoke test, observability, Tableau, Databricks, runbook reference
+- `docs/deployment/troubleshooting.md`: connection errors, query errors, performance, Docker startup, Tableau-specific, logging/diagnostics guidance
+
+### Smoke test script
+- `scripts/smoke-test.sh`: tests HTTP health, pgwire connectivity, metadata facade, optional real Databricks query; exit 0 on pass / exit 1 on fail
+
+### Module README
+- `skadi-sql-gateway/README.md`: rewritten with quick start, ports, auth modes, build/test, Docker, config reference, health endpoints, links to deployment guides
 
 ---
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,110 @@
+# Skadi SQL Gateway — Deployment Guide
+
+Skadi SQL Gateway exposes a PostgreSQL wire-protocol endpoint that Tableau Desktop,
+Tableau Server, Tableau Bridge, DBeaver, and any PostgreSQL JDBC client can connect to,
+proxying queries through to Databricks SQL Warehouse.
+
+---
+
+## Quick navigation
+
+| Guide | When to use |
+|---|---|
+| [Docker deployment](docker.md) | Containerised deployment (recommended for production) |
+| [Tableau Server](tableau-server.md) | Connecting Tableau Server to the gateway |
+| [Tableau Bridge / Cloud](tableau-bridge.md) | Connecting Tableau Cloud via Tableau Bridge |
+| [Production checklist](production-checklist.md) | Pre-go-live verification |
+| [Troubleshooting](troubleshooting.md) | Common issues and fixes |
+
+---
+
+## Architecture overview
+
+```
+Tableau Desktop / Server / Bridge
+        │  PostgreSQL wire protocol (port 15432)
+        ▼
+  Skadi SQL Gateway
+  ┌─────────────────────────────────────────────────────┐
+  │  pgwire listener          (PgWireServer)            │
+  │  SQL dialect bridge       (SqlDialectBridge)        │
+  │  Query result cache       (QueryResultCache)        │
+  │  Metadata facade          (MetadataQueryRouter)     │
+  └──────────────────────────┬──────────────────────────┘
+                             │  Databricks JDBC
+                             ▼
+                  Databricks SQL Warehouse
+```
+
+---
+
+## Ports
+
+| Port | Protocol | Purpose |
+|---|---|---|
+| `15432` | TCP — PostgreSQL wire | Tableau, DBeaver, psql client connections |
+| `8090` | HTTP | Spring Boot Actuator (health, metrics, Prometheus) |
+
+---
+
+## Minimum requirements
+
+| Component | Requirement |
+|---|---|
+| Java | 21+ (Eclipse Temurin recommended) |
+| RAM | 512 MB minimum; 2 GB recommended (cache + JDBC pool) |
+| Network | Outbound TCP to Databricks workspace on port 443 |
+| Databricks | SQL Warehouse (Serverless or Pro); HTTP path + PAT token |
+| Tableau | Desktop 2022.1+, Server 2022.1+, or Bridge latest |
+
+---
+
+## Key configuration reference
+
+All settings can be supplied as **environment variables** using Spring Boot's convention:
+replace `.` with `_` and `-` with `_`, then uppercase.
+
+| YAML key | Environment variable | Default | Notes |
+|---|---|---|---|
+| `skadi.sql-gateway.pgwire.enabled` | `SKADI_SQL_GATEWAY_PGWIRE_ENABLED` | `false` | Must be `true` |
+| `skadi.sql-gateway.pgwire.port` | `SKADI_SQL_GATEWAY_PGWIRE_PORT` | `15432` | |
+| `skadi.sql-gateway.pgwire.auth.mode` | `SKADI_SQL_GATEWAY_PGWIRE_AUTH_MODE` | `trust` | Use `password` for production |
+| `skadi.sql-gateway.pgwire.query-timeout` | `SKADI_SQL_GATEWAY_PGWIRE_QUERY_TIMEOUT` | *(none)* | e.g. `5m` |
+| `skadi.sql-gateway.pgwire.max-concurrent-queries-per-user` | `SKADI_SQL_GATEWAY_PGWIRE_MAX_CONCURRENT_QUERIES_PER_USER` | `0` (unlimited) | |
+| `skadi.sql-gateway.databricks.enabled` | `SKADI_SQL_GATEWAY_DATABRICKS_ENABLED` | `false` | Must be `true` |
+| `skadi.sql-gateway.databricks.host` | `SKADI_SQL_GATEWAY_DATABRICKS_HOST` | | `<workspace>.azuredatabricks.net` |
+| `skadi.sql-gateway.databricks.http-path` | `SKADI_SQL_GATEWAY_DATABRICKS_HTTP_PATH` | | `/sql/1.0/warehouses/<id>` |
+| `skadi.sql-gateway.databricks.token` | `SKADI_SQL_GATEWAY_DATABRICKS_TOKEN` | | PAT token (keep secret) |
+| `skadi.sql-gateway.databricks.max-pool-size` | `SKADI_SQL_GATEWAY_DATABRICKS_MAX_POOL_SIZE` | `5` | |
+| `skadi.sql-gateway.metadata.dbx-catalog` | `SKADI_SQL_GATEWAY_METADATA_DBX_CATALOG` | `main` | Unity Catalog name |
+| `skadi.sql-gateway.metadata.dbx-schema` | `SKADI_SQL_GATEWAY_METADATA_DBX_SCHEMA` | `public` | Schema to expose |
+| `skadi.sql-gateway.cache.enabled` | `SKADI_SQL_GATEWAY_CACHE_ENABLED` | `true` | |
+| `skadi.sql-gateway.cache.ttl` | `SKADI_SQL_GATEWAY_CACHE_TTL` | `5m` | |
+
+> **Secret handling:** never pass `SKADI_SQL_GATEWAY_DATABRICKS_TOKEN` as a plain environment
+> variable in a shared environment. Use your orchestrator's secret management (k8s Secrets,
+> Docker secrets, Vault, AWS Secrets Manager) to inject it at runtime.
+
+---
+
+## Health checks
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /actuator/health` | Overall application health (includes pgwire listener status) |
+| `GET /actuator/health/pgWire` | pgwire listener specifically (use as readiness probe) |
+| `GET /actuator/metrics` | Micrometer metric names |
+| `GET /actuator/prometheus` | Prometheus scrape endpoint |
+| `GET /ping` | Simple liveness check (returns `ok`) |
+
+The `pgWire` health indicator reports `UP` only once the pgwire socket is bound and accepting
+connections. Use it as the **readiness probe** in k8s or load-balancer health checks so traffic
+only reaches the gateway after the pgwire port is ready.
+
+---
+
+## Next steps
+
+- [Docker deployment guide](docker.md) — getting the gateway running in 5 minutes
+- [Tableau Server guide](tableau-server.md) — setting up published data sources
+- [Tableau Bridge / Cloud guide](tableau-bridge.md) — connecting Tableau Cloud

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,0 +1,251 @@
+# Docker Deployment
+
+This guide covers building and running Skadi SQL Gateway as a Docker container.
+
+---
+
+## Prerequisites
+
+- Docker 24+ with BuildKit enabled
+- A Databricks workspace with a SQL Warehouse
+- `docker compose` plugin (or Docker Compose v2)
+
+---
+
+## 1. Build the image
+
+From the repository root:
+
+```bash
+# Standard build (pulls dependencies from Maven Central)
+docker build -f skadi-sql-gateway/Dockerfile -t skadi-sql-gateway:latest .
+
+# With BuildKit cache (faster rebuilds during development)
+DOCKER_BUILDKIT=1 docker build \
+  -f skadi-sql-gateway/Dockerfile \
+  -t skadi-sql-gateway:latest .
+```
+
+> The Databricks JDBC driver is **not included** in the image (it is `provided`/`optional`
+> in the build). See [Adding the Databricks JDBC driver](#adding-the-databricks-jdbc-driver).
+
+---
+
+## 2. Configure credentials
+
+Create a `.env` file (never commit this):
+
+```bash
+# skadi-sql-gateway/.env — local overrides
+DATABRICKS_ENABLED=true
+DATABRICKS_HOST=<workspace>.azuredatabricks.net
+DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/<warehouse-id>
+DATABRICKS_TOKEN=dapi...
+
+DBX_CATALOG=main
+DBX_SCHEMA=sales
+
+PGWIRE_AUTH_MODE=password
+QUERY_TIMEOUT=5m
+MAX_CONCURRENT=10
+CACHE_TTL=5m
+```
+
+---
+
+## 3. Run with Docker Compose
+
+```bash
+cd skadi-sql-gateway
+docker compose up -d
+```
+
+Verify the gateway is healthy:
+
+```bash
+# HTTP health check
+curl -s http://localhost:8090/actuator/health | python3 -m json.tool
+
+# pgwire smoke test (requires psql)
+psql -h localhost -p 15432 -U demo postgres -c "SELECT 1"
+```
+
+---
+
+## 4. Run with Docker directly
+
+```bash
+docker run -d \
+  --name skadi-sql-gateway \
+  -p 15432:15432 \
+  -p 8090:8090 \
+  -e SKADI_SQL_GATEWAY_PGWIRE_ENABLED=true \
+  -e SKADI_SQL_GATEWAY_PGWIRE_AUTH_MODE=password \
+  -e SKADI_SQL_GATEWAY_DATABRICKS_ENABLED=true \
+  -e SKADI_SQL_GATEWAY_DATABRICKS_HOST="<workspace>.azuredatabricks.net" \
+  -e SKADI_SQL_GATEWAY_DATABRICKS_HTTP_PATH="/sql/1.0/warehouses/<id>" \
+  -e SKADI_SQL_GATEWAY_DATABRICKS_TOKEN="dapi..." \
+  -e SKADI_SQL_GATEWAY_METADATA_DBX_CATALOG="main" \
+  -e SKADI_SQL_GATEWAY_METADATA_DBX_SCHEMA="sales" \
+  --restart unless-stopped \
+  skadi-sql-gateway:latest
+```
+
+---
+
+## Adding the Databricks JDBC driver
+
+The Databricks JDBC driver must be present at runtime for Databricks connectivity.
+Download it from: https://www.databricks.com/spark/jdbc-drivers-download
+
+**Option A — Extend the image (recommended for production):**
+
+```dockerfile
+FROM skadi-sql-gateway:latest
+COPY databricks-jdbc-2.x.x.jar /app/BOOT-INF/lib/
+```
+
+Rebuild:
+```bash
+docker build -t skadi-sql-gateway:with-dbx-driver .
+```
+
+**Option B — Mount as a volume:**
+
+Add `JAVA_TOOL_OPTIONS` to point to the mounted jar:
+
+```bash
+docker run ... \
+  -e JAVA_TOOL_OPTIONS="-cp /drivers/databricks-jdbc.jar" \
+  -v /host/path/to/drivers:/drivers:ro \
+  skadi-sql-gateway:latest
+```
+
+---
+
+## TLS in front of the gateway (recommended for production)
+
+The gateway listens on plain TCP. Wrap it with a TLS-terminating proxy:
+
+**stunnel example** (`/etc/stunnel/skadi.conf`):
+
+```ini
+[skadi-pgwire]
+accept  = 5432
+connect = 127.0.0.1:15432
+cert    = /etc/ssl/certs/skadi.crt
+key     = /etc/ssl/private/skadi.key
+```
+
+**nginx stream proxy example** (`nginx.conf`):
+
+```nginx
+stream {
+    upstream skadi_pgwire {
+        server skadi-sql-gateway:15432;
+    }
+    server {
+        listen 5432 ssl;
+        ssl_certificate     /etc/ssl/skadi.crt;
+        ssl_certificate_key /etc/ssl/skadi.key;
+        proxy_pass skadi_pgwire;
+    }
+}
+```
+
+Point Tableau at the proxy host on port 5432 with `SSL=Required`.
+
+---
+
+## Prometheus / Grafana (optional)
+
+Uncomment the `prometheus` and `grafana` services in `docker-compose.yml`.
+
+Create `monitoring/prometheus.yml`:
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: skadi-sql-gateway
+    static_configs:
+      - targets: ['skadi-sql-gateway:8090']
+    metrics_path: /actuator/prometheus
+```
+
+Key metrics to dashboard:
+- `skadi_sessions_active` — active client connections
+- `skadi_queries_seconds_count` — QPS by cache tier
+- `skadi_queries_seconds{quantile="0.99"}` — p99 query latency
+- `skadi_query_errors_total` — errors by SQLSTATE
+
+---
+
+## Kubernetes (no Helm chart yet)
+
+A minimal k8s `Deployment` + `Service`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skadi-sql-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: skadi-sql-gateway
+  template:
+    metadata:
+      labels:
+        app: skadi-sql-gateway
+    spec:
+      containers:
+        - name: skadi-sql-gateway
+          image: skadi-sql-gateway:latest
+          ports:
+            - containerPort: 15432
+              name: pgwire
+            - containerPort: 8090
+              name: http
+          env:
+            - name: SKADI_SQL_GATEWAY_PGWIRE_ENABLED
+              value: "true"
+            - name: SKADI_SQL_GATEWAY_DATABRICKS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: skadi-secrets
+                  key: databricks-token
+            # ... other env vars
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8090
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/pgWire
+              port: 8090
+            initialDelaySeconds: 20
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: skadi-sql-gateway
+spec:
+  selector:
+    app: skadi-sql-gateway
+  ports:
+    - name: pgwire
+      port: 15432
+      targetPort: 15432
+    - name: http
+      port: 8090
+      targetPort: 8090
+```
+
+> Note: Use `readinessProbe` on `/actuator/health/pgWire` so the pod only receives
+> traffic once the pgwire listener is bound and ready.

--- a/docs/deployment/production-checklist.md
+++ b/docs/deployment/production-checklist.md
@@ -1,0 +1,127 @@
+# Production Checklist — Skadi SQL Gateway
+
+Work through this checklist before promoting the gateway to production traffic.
+Each item links to the relevant guide section.
+
+---
+
+## Infrastructure
+
+- [ ] Gateway deployed with `restart: unless-stopped` (Docker) or `restartPolicy: Always` (k8s)
+- [ ] At least **512 MB RAM** allocated; **2 GB recommended** for cache + JDBC pool
+- [ ] CPU: at minimum 1 vCPU; 2–4 vCPU for production under concurrent load
+- [ ] Gateway host can reach `<workspace>.azuredatabricks.net:443` outbound
+
+---
+
+## Configuration
+
+- [ ] `SKADI_SQL_GATEWAY_PGWIRE_ENABLED=true`
+- [ ] `SKADI_SQL_GATEWAY_DATABRICKS_ENABLED=true`
+- [ ] `SKADI_SQL_GATEWAY_DATABRICKS_HOST` set to correct workspace hostname
+- [ ] `SKADI_SQL_GATEWAY_DATABRICKS_HTTP_PATH` set to correct warehouse HTTP path
+- [ ] `SKADI_SQL_GATEWAY_DATABRICKS_TOKEN` injected via secret manager (not plain env var)
+- [ ] `SKADI_SQL_GATEWAY_PGWIRE_AUTH_MODE=password` (not `trust`)
+- [ ] At least one user configured in `SKADI_SQL_GATEWAY_PGWIRE_AUTH_USERS_<NAME>`
+- [ ] Passwords use bcrypt: `SKADI_SQL_GATEWAY_PGWIRE_AUTH_CREDENTIAL_STORE=bcrypt`
+- [ ] `SKADI_SQL_GATEWAY_PGWIRE_QUERY_TIMEOUT` set (e.g., `5m`)
+- [ ] `SKADI_SQL_GATEWAY_PGWIRE_MAX_CONCURRENT_QUERIES_PER_USER` set (e.g., `10`)
+- [ ] `SKADI_SQL_GATEWAY_DATABRICKS_MAX_POOL_SIZE` tuned for expected concurrency (default 5)
+- [ ] `SKADI_SQL_GATEWAY_METADATA_DBX_CATALOG` set to correct Unity Catalog name
+- [ ] `SKADI_SQL_GATEWAY_METADATA_DBX_SCHEMA` set to the schema to expose
+
+---
+
+## Security
+
+- [ ] Databricks PAT token stored in secret manager (k8s Secret, Vault, AWS Secrets Manager, etc.)
+- [ ] Databricks PAT token has minimum required permissions (SELECT on target schema)
+- [ ] Gateway not directly accessible from the public internet (firewall / security group)
+- [ ] Port 15432 open only to known Tableau Server / Bridge IP ranges
+- [ ] Port 8090 (Actuator) accessible only from internal monitoring systems
+- [ ] TLS-terminating proxy (stunnel or nginx) deployed in front of port 15432 — see [docker.md](docker.md#tls-in-front-of-the-gateway-recommended-for-production)
+- [ ] Tableau connection configured with `SSL=Required` pointing at TLS proxy
+- [ ] Auth mode `trust` is **not** used
+- [ ] `.env` file (if used) not committed to git; added to `.gitignore`
+- [ ] `PrincipalPolicy` ACLs configured to restrict users to their authorized schemas
+
+---
+
+## Health checks
+
+- [ ] `GET /actuator/health` returns `{"status":"UP"}`
+- [ ] `GET /actuator/health/pgWire` returns `{"status":"UP","details":{"port":15432,...}}`
+- [ ] `GET /ping` returns `ok`
+- [ ] k8s / load balancer readiness probe configured on `/actuator/health/pgWire`
+- [ ] k8s / load balancer liveness probe configured on `/actuator/health`
+
+---
+
+## Connectivity smoke test
+
+```bash
+# From a machine with psql installed and network access to the gateway
+
+# 1. Basic connectivity (trust mode / known user)
+psql -h <gateway-host> -p 15432 -U <user> postgres -c "SELECT 1"
+
+# 2. Information schema (metadata facade)
+psql -h <gateway-host> -p 15432 -U <user> postgres \
+  -c "SELECT table_name FROM information_schema.tables LIMIT 5"
+
+# 3. Real Databricks query (replace with a table in your schema)
+psql -h <gateway-host> -p 15432 -U <user> postgres \
+  -c "SELECT COUNT(*) FROM <your-schema>.<your-table>"
+```
+
+Or run the full smoke-test script:
+
+```bash
+./scripts/smoke-test.sh --host <gateway-host> --user <user> --password <password>
+```
+
+---
+
+## Observability
+
+- [ ] Prometheus scraping `/actuator/prometheus` — see [docker.md](docker.md#prometheus--grafana-optional)
+- [ ] Grafana dashboards imported or created for:
+  - `skadi_sessions_active` — active connections
+  - `skadi_queries_seconds_count` — QPS by cache tier
+  - `skadi_queries_seconds{quantile="0.99"}` — p99 query latency
+  - `skadi_query_errors_total` — error rate by SQLSTATE
+- [ ] Alerting configured on:
+  - `skadi_query_errors_total` rate spikes
+  - `skadi_queries_seconds{quantile="0.99"}` exceeding SLA threshold
+  - Gateway health endpoint returning non-`UP`
+
+---
+
+## Tableau connectivity
+
+- [ ] Tableau Desktop can connect to the gateway (see [tableau-server.md](tableau-server.md))
+- [ ] Published data sources on Tableau Server refresh successfully
+- [ ] Tableau Bridge agent running and connected to Tableau Cloud site (if applicable — see [tableau-bridge.md](tableau-bridge.md))
+- [ ] SSL mode configured correctly in Tableau data source connections
+
+---
+
+## Databricks SQL Warehouse
+
+- [ ] Warehouse type is **Serverless** or **Pro** (Classic warehouses have longer cold-start times)
+- [ ] Warehouse auto-stop configured appropriately (consider keeping alive during business hours)
+- [ ] Warehouse cluster policy allows the service account to run queries
+- [ ] Unity Catalog permissions: `SELECT` on the target schema's tables; `USE SCHEMA`; `USE CATALOG`
+
+---
+
+## Runbook reference
+
+| Scenario | Action |
+|---|---|
+| Gateway won't start | Check `docker logs skadi-sql-gateway`; verify JDBC jar present and credentials correct |
+| Tableau "Connection Error" | Check pgwire port reachability; verify auth mode and credentials |
+| All queries timing out | Check Databricks warehouse status; increase `QUERY_TIMEOUT` or pool size |
+| High error rate | Check `skadi_query_errors_total` labels; review audit log for `SQLSTATE` codes |
+| Cache not working | Verify `CACHE_ENABLED=true`; check `skadi_queries_seconds` `cache_tier` labels |
+| JDBC driver missing | Extend image or mount driver — see [docker.md](docker.md#adding-the-databricks-jdbc-driver) |

--- a/docs/deployment/tableau-bridge.md
+++ b/docs/deployment/tableau-bridge.md
@@ -1,0 +1,151 @@
+# Tableau Bridge / Tableau Cloud — Connecting to Skadi SQL Gateway
+
+This guide covers connecting **Tableau Cloud** to Skadi SQL Gateway via **Tableau Bridge**,
+which runs on-premises and relays queries from Tableau Cloud to the gateway.
+
+---
+
+## Overview
+
+```
+Tableau Cloud (cloud.tableau.com)
+        │  Tableau Bridge relay (outbound from your network)
+        ▼
+ Tableau Bridge Agent (on-premises / VPC)
+        │  PostgreSQL wire protocol  port 15432
+        ▼
+  Skadi SQL Gateway
+        │  Databricks JDBC  port 443
+        ▼
+  Databricks SQL Warehouse
+```
+
+Tableau Bridge runs inside your network and makes **outbound** connections to Tableau Cloud.
+No inbound firewall rules are needed for Tableau Cloud itself — only the Bridge agent needs
+outbound TCP 443 to `online.tableau.com` and TCP 15432 to the Skadi gateway.
+
+---
+
+## Prerequisites
+
+- Tableau Cloud site (formerly Tableau Online)
+- Tableau Bridge agent installed on a Windows or Linux machine with access to the gateway
+- Skadi SQL Gateway running and healthy
+- Bridge agent machine can reach `<skadi-host>:15432` over TCP
+
+---
+
+## 1. Install Tableau Bridge
+
+Download Tableau Bridge from your Tableau Cloud site:
+
+1. Sign in to Tableau Cloud.
+2. Navigate to **Settings → Bridge**.
+3. Download the Bridge client for your OS (Windows recommended; Linux available as of Bridge 2023.1).
+4. Install and sign in with your Tableau Cloud site credentials.
+5. Leave Bridge running — it will appear in the Bridge pool.
+
+---
+
+## 2. Create the data source in Tableau Desktop
+
+Configure the connection on Tableau Desktop first, then publish it to Tableau Cloud:
+
+1. Open Tableau Desktop.
+2. Connect → **PostgreSQL**.
+3. Fill in connection details pointing to the Skadi gateway (same as for Tableau Server —
+   see [tableau-server.md](tableau-server.md#1-connect-from-tableau-desktop)).
+4. Build your view or data model.
+5. **Server → Sign In to Tableau Cloud**.
+6. **Server → Publish Data Source**.
+
+When publishing, Tableau Desktop will prompt you to choose a **connectivity method**:
+
+- Select **Tableau Bridge** (not "Tableau Extracts" unless you want a static snapshot).
+
+---
+
+## 3. Configure the Bridge connection
+
+After publishing, the data source appears in Tableau Cloud with status **Waiting for Bridge**:
+
+1. In Tableau Cloud, open the data source.
+2. Under **Connections**, verify the connection points to your gateway host and port 15432.
+3. Under **Scheduled Refreshes**, Bridge will now handle live queries or scheduled extracts.
+
+If the data source shows **Connection Error**, check that:
+- The Bridge agent is running and signed in.
+- The Bridge machine can reach the gateway host on port 15432.
+- Credentials are embedded (Bridge uses them to authenticate to the gateway).
+
+---
+
+## 4. Embedded credentials for Bridge
+
+Bridge requires credentials to be embedded in the published data source for background
+refresh to work:
+
+1. During publish from Tableau Desktop, choose **Embed password in connection**.
+2. After publishing, in Tableau Cloud under the data source → **Connections → Edit**,
+   verify the credentials are stored.
+
+> In `password` auth mode, the gateway validates these credentials against its user store.
+> In `trust` mode, any username is accepted (suitable only for dev/staging).
+
+---
+
+## 5. Live connections vs. extracts
+
+| Mode | How it works | When to use |
+|---|---|---|
+| **Live (via Bridge)** | Tableau Cloud routes each query through Bridge to the gateway; Bridge relays to Databricks | When data must be fresh; Databricks SQL Warehouse is always-on |
+| **Extract** | Bridge pulls a full dataset snapshot and uploads to Tableau Cloud | When Databricks Warehouse is serverless (cold start adds latency); when data volume is manageable |
+| **Scheduled extract** | Bridge fetches at a schedule; intermediate data stored in Tableau Cloud | Best for most Tableau Cloud deployments |
+
+For extract mode, the gateway handles the full data pull (which may be slow for large tables).
+The gateway's cache does not help significantly here since extracts are typically ad-hoc large scans.
+
+---
+
+## 6. Firewall and network summary
+
+| Connection | Source | Destination | Port |
+|---|---|---|---|
+| Bridge → Tableau Cloud | Bridge agent | `online.tableau.com` | 443 (HTTPS) |
+| Bridge → Skadi gateway | Bridge agent | `<skadi-host>` | 15432 (TCP) |
+| Skadi gateway → Databricks | Gateway | `<workspace>.azuredatabricks.net` | 443 (HTTPS) |
+
+No inbound ports needed on the Bridge machine or the gateway (beyond Tableau Server or
+other internal clients that connect directly).
+
+---
+
+## 7. TLS considerations
+
+Tableau Bridge supports SSL on the PostgreSQL connection:
+
+- If the gateway is behind a TLS proxy (port 5432 with SSL), set **SSL Mode = Required**
+  in the Tableau Desktop connection dialog before publishing.
+- Bridge will preserve the SSL setting from the published data source.
+
+Without TLS: connections between Bridge and the gateway are plain TCP. This is acceptable
+when Bridge and the gateway are co-located in the same VPC or private network.
+
+---
+
+## 8. Bridge agent sizing
+
+| Workload | Recommendation |
+|---|---|
+| \< 10 concurrent users | 4 vCPU, 8 GB RAM, single Bridge agent |
+| 10–50 concurrent users | 8 vCPU, 16 GB RAM, or 2 Bridge agents in pool |
+| \> 50 concurrent users | Multiple Bridge agents + gateway replicas |
+
+Bridge agents are stateless — add more by installing on additional machines and signing
+in to the same Tableau Cloud site.
+
+---
+
+## Troubleshooting
+
+See [troubleshooting.md](troubleshooting.md) for common Bridge connectivity errors and fixes.

--- a/docs/deployment/tableau-server.md
+++ b/docs/deployment/tableau-server.md
@@ -1,0 +1,135 @@
+# Tableau Server — Connecting to Skadi SQL Gateway
+
+This guide covers publishing and connecting Tableau Desktop and Tableau Server to the
+Skadi SQL Gateway using the **PostgreSQL connector**.
+
+---
+
+## Prerequisites
+
+- Skadi SQL Gateway running and healthy (`GET /actuator/health/pgWire` → `UP`)
+- Tableau Desktop 2022.1+ or Tableau Server 2022.1+
+- Network path from the Tableau machine to the gateway host on port `15432`
+- (Optional) Tableau Server Repository password if publishing data sources
+
+---
+
+## 1. Connect from Tableau Desktop
+
+1. Open Tableau Desktop.
+2. In the left panel under **Connect → To a Server**, click **PostgreSQL**.
+3. Fill in the connection dialog:
+
+| Field | Value |
+|---|---|
+| Server | `<skadi-gateway-host>` |
+| Port | `15432` |
+| Database | `postgres` |
+| Username | Your configured user (e.g. `alice`), or any value in `trust` mode |
+| Password | User password (leave blank in `trust` mode) |
+| Require SSL | Check if TLS proxy is configured; leave unchecked for plain TCP |
+
+4. Click **Sign In**.
+
+Tableau sends a series of `information_schema` queries first — these are served from
+the in-memory metadata facade and return quickly. The first data query is forwarded to
+Databricks.
+
+### Selecting the schema
+
+After connecting, Tableau shows a database/schema picker:
+
+- **Database**: always `postgres` (the gateway presents a single logical database)
+- **Schema**: the schema configured as `skadi.sql-gateway.metadata.dbx-schema`
+  (default `default`). Set this to the Unity Catalog schema you want to expose.
+
+---
+
+## 2. Publish a data source to Tableau Server
+
+From Tableau Desktop with an open data source:
+
+1. **Server → Publish Data Source → \<data source name\>**
+2. Choose the Tableau Server project.
+3. Under **Data Source**, select **Allow refresh access**.
+4. Click **Publish**.
+
+Tableau Server will try to refresh the data source on its scheduled interval.
+The gateway must be reachable from Tableau Server's network — not just from your desktop.
+
+---
+
+## 3. Embedded credentials
+
+When publishing, Tableau will ask whether to **embed** the Skadi credentials in the
+published data source or prompt users at connect time.
+
+- **Embed credentials** — recommended for service accounts. Tableau Server stores the
+  username/password and uses them for background refreshes.
+- **Prompt users** — users authenticate with their own Skadi credentials when they open
+  the workbook from the browser.
+
+> For multi-tenant deployments, `PrincipalPolicy` ACLs in the gateway limit each user to
+> their authorized schemas regardless of what the workbook specifies.
+
+---
+
+## 4. Scheduling data source refreshes
+
+On Tableau Server:
+
+1. Open the data source on the server.
+2. Click **Schedule** → choose a refresh schedule.
+3. Verify the first refresh completes: check **Data Source → Refresh History**.
+
+The gateway serves cached results for repeat queries within the TTL window (`cache.ttl`,
+default 5 min). If the schedule fires more frequently than the TTL, Tableau still gets
+fresh data, but the gateway deduplicates the underlying Databricks calls.
+
+---
+
+## 5. Firewall / network requirements
+
+| Direction | Source | Destination | Port | Protocol |
+|---|---|---|---|---|
+| Inbound to gateway | Tableau Desktop / Server | Skadi gateway | 15432 | TCP |
+| Outbound from gateway | Skadi gateway | Databricks workspace | 443 | HTTPS (JDBC) |
+
+If Tableau Server sits behind a corporate proxy, ensure the proxy allows outbound TCP
+on port 15432 (or whichever port the gateway is on), or use a TLS-terminating proxy
+on port 5432.
+
+---
+
+## 6. Configuring SSL
+
+If the gateway is fronted by a TLS-terminating proxy (stunnel or nginx — see
+[docker.md](docker.md#tls-in-front-of-the-gateway-recommended-for-production)):
+
+1. In Tableau Desktop connection dialog, check **Require SSL**.
+2. In the published data source on Tableau Server, edit the connection and set SSL mode
+   to **Required**.
+3. Point the connection at the proxy host/port (e.g., port 5432), not the raw gateway.
+
+Without a TLS proxy, leave SSL unchecked. The gateway does not handle TLS natively.
+
+---
+
+## 7. Supported Tableau features
+
+| Feature | Supported | Notes |
+|---|---|---|
+| Live connection | Yes | Queries forwarded to Databricks in real time |
+| Extract | Yes | Tableau pulls rows; gateway streams them |
+| Published data source | Yes | Credentials embedded or user-prompted |
+| Scheduled refresh | Yes | Background refresh via embedded credentials |
+| Row-level security | Partial | Use `PrincipalPolicy` ACL to restrict schemas |
+| Custom SQL | Yes | Arbitrary SQL forwarded and translated |
+| Cross-database joins | No | Single logical database (`postgres`) |
+| Tableau Prep | Yes | Connects via same PostgreSQL connector |
+
+---
+
+## Troubleshooting
+
+See [troubleshooting.md](troubleshooting.md) for common Tableau connection errors and fixes.

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -1,0 +1,263 @@
+# Troubleshooting — Skadi SQL Gateway
+
+Common issues, their likely causes, and fixes.
+
+---
+
+## Connection issues
+
+### `Connection refused` on port 15432
+
+**Symptoms:** `psql: error: connection to server at "<host>" (x.x.x.x), port 15432 failed: Connection refused`
+
+**Causes / fixes:**
+
+1. Gateway is not running — check `docker ps` or `kubectl get pods`.
+2. pgwire is not enabled — verify `SKADI_SQL_GATEWAY_PGWIRE_ENABLED=true`.
+3. Port mapping wrong — check `docker ps` shows `0.0.0.0:15432->15432/tcp`.
+4. Firewall is blocking — confirm port 15432 is open between Tableau and gateway host.
+
+---
+
+### `SSL connection has been closed unexpectedly` (Tableau Desktop)
+
+**Cause:** Tableau tried to upgrade to SSL but the gateway does not handle TLS natively.
+
+**Fix:** Either:
+- Uncheck **Require SSL** in the Tableau connection dialog and connect to port 15432 directly.
+- Deploy a TLS-terminating proxy (see [docker.md](docker.md#tls-in-front-of-the-gateway-recommended-for-production)) and point Tableau at the proxy port with SSL enabled.
+
+---
+
+### `FATAL: password authentication failed`
+
+**Cause:** Auth mode is `password` and the supplied credentials do not match any configured user.
+
+**Fixes:**
+1. Verify `SKADI_SQL_GATEWAY_PGWIRE_AUTH_USERS_<USERNAME>` is set with the correct password.
+2. If using bcrypt, ensure the stored hash was generated correctly
+   (`htpasswd -bnBC 12 "" <password> | tr -d ':\n'`).
+3. In dev/staging, switch to `trust` mode temporarily to confirm connectivity.
+
+---
+
+### Tableau "An error occurred while communicating with the PostgreSQL data source"
+
+**Cause:** Gateway returned a protocol error or an unexpected SQL error.
+
+**Fix:**
+1. Check gateway logs: `docker logs skadi-sql-gateway | tail -100`
+2. Look for `ERROR` or `WARN` lines with a `session_id` matching the Tableau connection time.
+3. Try the same query from `psql` to narrow down whether it's a Tableau-specific issue.
+
+---
+
+### `psql: error: SSL connection required`
+
+**Cause:** The gateway has `require-ssl=true` but the client connected without SSL.
+
+**Fix:** Either disable `require-ssl`, or connect with `psql "sslmode=require ..."`.
+
+---
+
+## Query errors
+
+### `42601 — syntax error` when Tableau sends a query
+
+**Cause:** A Tableau-generated query uses PostgreSQL syntax that the SQL dialect bridge
+does not yet translate.
+
+**Fix:**
+1. Capture the raw SQL from the gateway logs (look for `Forwarding query` log lines).
+2. Check `SqlDialectBridge` and `SqlNormalizer` for missing transformations.
+3. As a workaround, use a Tableau **Custom SQL** data source with Databricks-compatible SQL.
+
+---
+
+### `Query exceeded timeout`
+
+**Cause:** The query ran longer than `SKADI_SQL_GATEWAY_PGWIRE_QUERY_TIMEOUT`.
+
+**Fixes:**
+1. Increase the timeout: `SKADI_SQL_GATEWAY_PGWIRE_QUERY_TIMEOUT=10m`.
+2. Check whether the Databricks warehouse is cold-starting — first query after idle period
+   can take 30–60 seconds on serverless warehouses.
+3. Add a `LIMIT` clause or narrow the date range of the query.
+
+---
+
+### All queries fail with `08001 — connection failed`
+
+**Cause:** The gateway cannot connect to Databricks. This usually means the JDBC driver
+is missing or credentials are wrong.
+
+**Fixes:**
+1. Confirm `DATABRICKS_ENABLED=true` and host/path/token are set.
+2. Check the Databricks JDBC driver is present — see
+   [docker.md](docker.md#adding-the-databricks-jdbc-driver).
+3. Verify the PAT token is valid and not expired.
+4. Check outbound TCP 443 from the gateway to the Databricks workspace is not blocked.
+
+---
+
+### `42501 — insufficient privilege`
+
+**Cause:** The Databricks service account (PAT token) does not have `SELECT` on the queried table.
+
+**Fix:** Grant the service account `SELECT` on the target schema:
+```sql
+GRANT SELECT ON SCHEMA <catalog>.<schema> TO `<service-account-email>`;
+```
+
+---
+
+### Queries return stale data
+
+**Cause:** The query result cache is serving old results.
+
+**Fix:**
+1. Reduce `SKADI_SQL_GATEWAY_CACHE_TTL` (default 5 min) for time-sensitive workloads.
+2. Disable cache temporarily: `SKADI_SQL_GATEWAY_CACHE_ENABLED=false`.
+3. Cache is keyed on normalized SQL + username — if the SQL changed slightly (different
+   whitespace, case), it may be treated as a new query.
+
+---
+
+## Databricks connectivity
+
+### First query is slow, subsequent queries are fast
+
+**Expected behaviour** on serverless SQL Warehouses — the warehouse cold-starts on the first
+query (30–90 seconds) and stays warm for subsequent queries within the auto-stop window.
+
+**Fix:** Set the Databricks warehouse auto-stop to a longer idle timeout during business hours,
+or use the Databricks API to pre-warm the warehouse before Tableau sessions begin.
+
+---
+
+### `java.lang.ClassNotFoundException: com.databricks.client.jdbc.Driver`
+
+**Cause:** The Databricks JDBC driver jar is not in the classpath.
+
+**Fix:** The driver is not bundled in the gateway image (it is `provided`/`optional` scope).
+Extend the image or mount the jar — see [docker.md](docker.md#adding-the-databricks-jdbc-driver).
+
+---
+
+## Performance
+
+### High p99 latency on cache misses
+
+**Causes:**
+1. Databricks warehouse is cold-starting.
+2. Query is doing a full table scan on a large table.
+3. JDBC connection pool is exhausted — increase `SKADI_SQL_GATEWAY_DATABRICKS_MAX_POOL_SIZE`.
+
+**Checks:**
+- Monitor `skadi_queries_seconds{quantile="0.99",cache_tier="miss"}` in Prometheus.
+- Check `skadi_sessions_active` to see concurrent session count.
+
+---
+
+### `Too many open connections`
+
+**Cause:** `MAX_CONCURRENT_QUERIES_PER_USER` or JDBC pool is the bottleneck.
+
+**Fix:**
+1. Increase `SKADI_SQL_GATEWAY_PGWIRE_MAX_CONCURRENT_QUERIES_PER_USER`.
+2. Increase `SKADI_SQL_GATEWAY_DATABRICKS_MAX_POOL_SIZE` (each additional unit requires
+   one Databricks warehouse cluster slot).
+3. For Tableau Server, reduce the number of concurrent background refresh jobs.
+
+---
+
+## Docker / startup
+
+### Gateway starts but `pgWire` health is `DOWN`
+
+**Cause:** pgwire failed to bind the port, or `pgwire.enabled=false`.
+
+**Checks:**
+```bash
+docker logs skadi-sql-gateway | grep -i "pgwire\|port\|bind\|error"
+curl http://localhost:8090/actuator/health/pgWire
+```
+
+**Fix:** Verify `SKADI_SQL_GATEWAY_PGWIRE_ENABLED=true` and that port 15432 is not already
+in use on the host (`ss -tlnp | grep 15432`).
+
+---
+
+### `OOMKilled` in k8s
+
+**Cause:** Container ran out of memory.
+
+**Fix:** Increase the container memory limit. The gateway needs at minimum 512 MB; 2 GB
+if the cache has many large results. Add JVM heap tuning via `JAVA_TOOL_OPTIONS`:
+
+```bash
+JAVA_TOOL_OPTIONS="-Xms256m -Xmx1g"
+```
+
+---
+
+## Tableau-specific
+
+### Tableau shows no tables after connecting
+
+**Cause:** `DBX_SCHEMA` is set to a schema that has no tables, or Unity Catalog permissions
+exclude the service account from seeing the tables.
+
+**Checks:**
+```bash
+psql -h localhost -p 15432 -U demo postgres \
+  -c "SELECT table_name FROM information_schema.tables WHERE table_schema = '<your-schema>'"
+```
+
+If empty, the metadata facade has no tables loaded. Check the gateway startup logs for
+metadata refresh errors.
+
+---
+
+### Tableau reports "The name was not found" for a column
+
+**Cause:** Tableau caches column metadata and a schema change occurred after the data source
+was published.
+
+**Fix:** In Tableau Desktop, right-click the data source → **Refresh**. Re-publish to Tableau Server.
+
+---
+
+### Repeated `SELECT 1` queries from Tableau
+
+**Expected behaviour** — Tableau sends keepalive queries to maintain the connection. These
+hit the cache (SQLSTATE `00000`, cache tier `hit`) and are essentially free.
+
+---
+
+## Logging and diagnostics
+
+Enable debug logging for the pgwire package temporarily:
+
+```yaml
+# application-local.yml (mount into container)
+logging:
+  level:
+    org.iceforge.skadi.sqlgateway.pgwire: DEBUG
+    org.iceforge.skadi.sqlgateway.dialect: DEBUG
+```
+
+Or via environment variable:
+```bash
+LOGGING_LEVEL_ORG_ICEFORGE_SKADI_SQLGATEWAY_PGWIRE=DEBUG
+```
+
+The audit log is at logger name `skadi.audit` — enable it at `INFO` to see all connect and
+query events:
+
+```bash
+LOGGING_LEVEL_SKADI_AUDIT=INFO
+```
+
+Each log line includes `session_id`, `user`, `query_id`, `cache_tier`, `rows`, and `latency_ms`
+for structured log queries (e.g., in Datadog, CloudWatch Logs Insights, or Loki).

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Smoke-test script for Skadi SQL Gateway.
+# Verifies: HTTP health, pgwire connectivity, metadata facade, and (optionally) a real Databricks query.
+set -euo pipefail
+
+# ── defaults ─────────────────────────────────────────────────────────────────
+HOST="${SKADI_HOST:-localhost}"
+PGWIRE_PORT="${SKADI_PGWIRE_PORT:-15432}"
+HTTP_PORT="${SKADI_HTTP_PORT:-8090}"
+USER="${SKADI_USER:-demo}"
+PASSWORD="${SKADI_PASSWORD:-}"
+DATABRICKS_TABLE="${SKADI_TEST_TABLE:-}"   # optional: schema.table for real data query
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+green() { printf '\033[0;32m✓ %s\033[0m\n' "$*"; }
+red()   { printf '\033[0;31m✗ %s\033[0m\n' "$*"; }
+yellow(){ printf '\033[0;33m~ %s\033[0m\n' "$*"; }
+
+pass() { green "$1"; ((PASS++)); }
+fail() { red   "$1"; ((FAIL++)); }
+skip() { yellow "$1 (skipped)"; ((SKIP++)); }
+
+psql_query() {
+    local sql="$1"
+    if [[ -n "$PASSWORD" ]]; then
+        PGPASSWORD="$PASSWORD" psql -h "$HOST" -p "$PGWIRE_PORT" -U "$USER" postgres \
+            --no-password -t -A -c "$sql" 2>&1
+    else
+        psql -h "$HOST" -p "$PGWIRE_PORT" -U "$USER" postgres \
+            --no-password -t -A -c "$sql" 2>&1
+    fi
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --host HOST          Gateway host (default: localhost)
+  --port PORT          pgwire port (default: 15432)
+  --http-port PORT     HTTP/Actuator port (default: 8090)
+  --user USER          Database user (default: demo)
+  --password PASS      User password (leave empty for trust mode)
+  --table SCHEMA.TABLE Run a real Databricks query against this table (optional)
+  -h, --help           Show this message
+
+Environment variables:
+  SKADI_HOST, SKADI_PGWIRE_PORT, SKADI_HTTP_PORT, SKADI_USER, SKADI_PASSWORD, SKADI_TEST_TABLE
+EOF
+    exit 0
+}
+
+# ── argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)       HOST="$2"; shift 2 ;;
+        --port)       PGWIRE_PORT="$2"; shift 2 ;;
+        --http-port)  HTTP_PORT="$2"; shift 2 ;;
+        --user)       USER="$2"; shift 2 ;;
+        --password)   PASSWORD="$2"; shift 2 ;;
+        --table)      DATABRICKS_TABLE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Skadi SQL Gateway Smoke Test"
+echo " Host:  $HOST"
+echo " Ports: pgwire=$PGWIRE_PORT  http=$HTTP_PORT"
+echo " User:  $USER"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── 1. HTTP health ────────────────────────────────────────────────────────────
+echo ""
+echo "[ HTTP health checks ]"
+
+HEALTH_URL="http://${HOST}:${HTTP_PORT}/actuator/health"
+if curl -sf --max-time 5 "$HEALTH_URL" -o /tmp/skadi_health.json; then
+    STATUS=$(python3 -c "import json,sys; d=json.load(open('/tmp/skadi_health.json')); print(d.get('status',''))" 2>/dev/null || echo "")
+    if [[ "$STATUS" == "UP" ]]; then
+        pass "Overall health is UP"
+    else
+        fail "Overall health returned: $STATUS"
+    fi
+else
+    fail "Cannot reach $HEALTH_URL"
+fi
+
+PGWIRE_HEALTH_URL="http://${HOST}:${HTTP_PORT}/actuator/health/pgWire"
+if curl -sf --max-time 5 "$PGWIRE_HEALTH_URL" -o /tmp/skadi_pgwire_health.json; then
+    PGWIRE_STATUS=$(python3 -c "import json,sys; d=json.load(open('/tmp/skadi_pgwire_health.json')); print(d.get('status',''))" 2>/dev/null || echo "")
+    if [[ "$PGWIRE_STATUS" == "UP" ]]; then
+        pass "pgWire health is UP"
+    else
+        fail "pgWire health returned: $PGWIRE_STATUS"
+    fi
+else
+    fail "Cannot reach $PGWIRE_HEALTH_URL"
+fi
+
+PING_URL="http://${HOST}:${HTTP_PORT}/ping"
+PING_RESP=$(curl -sf --max-time 5 "$PING_URL" 2>/dev/null || echo "")
+if [[ "$PING_RESP" == "ok" ]]; then
+    pass "/ping returned ok"
+else
+    fail "/ping returned: $PING_RESP"
+fi
+
+# ── 2. pgwire connectivity ────────────────────────────────────────────────────
+echo ""
+echo "[ pgwire connectivity ]"
+
+if ! command -v psql &>/dev/null; then
+    skip "psql not found — skipping pgwire tests (install postgresql-client)"
+else
+    RESULT=$(psql_query "SELECT 1" 2>&1)
+    if echo "$RESULT" | grep -q "^1$"; then
+        pass "SELECT 1 returned 1"
+    else
+        fail "SELECT 1 failed: $RESULT"
+    fi
+
+    RESULT=$(psql_query "SELECT current_database()" 2>&1)
+    if echo "$RESULT" | grep -q "postgres"; then
+        pass "current_database() returned postgres"
+    else
+        fail "current_database() returned: $RESULT"
+    fi
+
+    RESULT=$(psql_query "SELECT version()" 2>&1)
+    if echo "$RESULT" | grep -qi "postgresql"; then
+        pass "version() returned PostgreSQL-compatible string"
+    else
+        fail "version() returned: $RESULT"
+    fi
+
+    # ── 3. metadata facade ────────────────────────────────────────────────────
+    echo ""
+    echo "[ metadata facade ]"
+
+    RESULT=$(psql_query "SELECT count(*) FROM information_schema.tables" 2>&1)
+    if echo "$RESULT" | grep -qE "^[0-9]+$"; then
+        TABLE_COUNT=$RESULT
+        if [[ "$TABLE_COUNT" -gt 0 ]]; then
+            pass "information_schema.tables returned $TABLE_COUNT rows"
+        else
+            fail "information_schema.tables returned 0 rows — metadata facade may not be loaded"
+        fi
+    else
+        fail "information_schema.tables query failed: $RESULT"
+    fi
+
+    RESULT=$(psql_query "SELECT count(*) FROM information_schema.columns" 2>&1)
+    if echo "$RESULT" | grep -qE "^[0-9]+$"; then
+        pass "information_schema.columns returned $RESULT rows"
+    else
+        fail "information_schema.columns query failed: $RESULT"
+    fi
+
+    # ── 4. Databricks real query (optional) ───────────────────────────────────
+    echo ""
+    echo "[ Databricks connectivity ]"
+
+    if [[ -z "$DATABRICKS_TABLE" ]]; then
+        skip "No --table specified; skipping real Databricks query test"
+    else
+        RESULT=$(psql_query "SELECT COUNT(*) FROM $DATABRICKS_TABLE" 2>&1)
+        if echo "$RESULT" | grep -qE "^[0-9]+$"; then
+            pass "SELECT COUNT(*) FROM $DATABRICKS_TABLE returned $RESULT"
+        else
+            fail "Query against $DATABRICKS_TABLE failed: $RESULT"
+        fi
+    fi
+fi
+
+# ── summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Results: $PASS passed  |  $FAIL failed  |  $SKIP skipped"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ "$FAIL" -gt 0 ]]; then
+    echo " SMOKE TEST FAILED"
+    exit 1
+else
+    echo " SMOKE TEST PASSED"
+    exit 0
+fi

--- a/skadi-sql-gateway/Dockerfile
+++ b/skadi-sql-gateway/Dockerfile
@@ -1,0 +1,47 @@
+# ─── Build stage ─────────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jdk-jammy AS build
+WORKDIR /workspace
+
+# Copy Maven wrapper and parent POM (cache layer for dependency downloads)
+COPY mvnw ./
+COPY .mvn .mvn/
+COPY pom.xml ./
+COPY skadi-core/pom.xml skadi-core/
+COPY skadi-server/pom.xml skadi-server/
+COPY skadi-sql-gateway/pom.xml skadi-sql-gateway/
+
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw dependency:go-offline -pl skadi-sql-gateway -am -q --no-transfer-progress 2>/dev/null || true
+
+COPY skadi-core/src skadi-core/src/
+COPY skadi-server/src skadi-server/src/
+COPY skadi-sql-gateway/src skadi-sql-gateway/src/
+
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw package -pl skadi-sql-gateway -am -DskipTests --no-transfer-progress
+
+# ─── Runtime stage ────────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jre-jammy
+
+RUN groupadd --system skadi && useradd --system --gid skadi --no-create-home skadi
+WORKDIR /app
+
+COPY --from=build /workspace/skadi-sql-gateway/target/skadi-sql-gateway-*.jar app.jar
+
+# NOTE: The Databricks JDBC driver is NOT included (provided/optional scope).
+# To add it, extend this image:
+#   FROM ghcr.io/iceforge-io/skadi-sql-gateway:latest
+#   COPY databricks-jdbc-2.x.jar /app/BOOT-INF/lib/
+# Or mount it and set JAVA_TOOL_OPTIONS=-cp /opt/drivers/databricks-jdbc.jar
+
+USER skadi
+
+# pgwire — Tableau / DBeaver / psql connect here
+EXPOSE 15432
+# HTTP — Spring Boot Actuator (health, metrics, Prometheus)
+EXPOSE 8090
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=45s --retries=3 \
+    CMD wget -q -O /dev/null "http://localhost:8090/actuator/health" || exit 1
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/skadi-sql-gateway/README.md
+++ b/skadi-sql-gateway/README.md
@@ -1,37 +1,131 @@
 # skadi-sql-gateway
 
-> NOTE: password mode is for local/dev only right now.
+PostgreSQL wire-protocol gateway that lets Tableau, DBeaver, and any `psql` client connect
+to Databricks SQL Warehouse as if it were a PostgreSQL server.
 
-- `password`: cleartext password auth against `skadi.sql-gateway.pgwire.auth.users`.
-- `trust` (default): accepts any username.
+---
 
-Configured under `skadi.sql-gateway.pgwire.auth.mode`:
+## Quick start
 
-### Auth modes
+```bash
+# From repo root — run locally
+./mvnw spring-boot:run -pl skadi-sql-gateway
 
+# Connect with psql (trust mode by default)
+psql -h 127.0.0.1 -p 15432 -U demo postgres -c "SELECT 1"
 ```
-#   select 1;
-# then:
-psql -h 127.0.0.1 -p 15432 -U test postgres
-# in another shell
 
-.\mvnw.cmd -pl skadi-sql-gateway -am spring-boot:run
-# run the app (gateway has both HTTP + pgwire listeners)
+---
 
-.\mvnw.cmd -pl skadi-sql-gateway -am test
-# from repo root
-```powershell
+## Ports
 
-### Try with psql
+| Port | Protocol | Purpose |
+|---|---|---|
+| `15432` | TCP — PostgreSQL wire | Tableau, DBeaver, psql |
+| `8090` | HTTP | Spring Boot Actuator (health, metrics, Prometheus) |
 
-- pgwire (PostgreSQL protocol): `15432`
-- HTTP (Spring Boot): `8090`
+---
 
-### Default ports
+## Auth modes
 
-This module contains a minimal PostgreSQL protocol listener intended to unblock Tableau/JDBC connectivity.
+Configured via `skadi.sql-gateway.pgwire.auth.mode`:
 
-## pgwire (PostgreSQL wire protocol) MVP
+| Mode | Description |
+|---|---|
+| `trust` (default) | Accepts any username, no password required. Dev/CI only. |
+| `password` | Validates credentials against configured users. Use for production. |
 
-Minimal SQL gateway service.
+Example `application.yml` for password mode:
 
+```yaml
+skadi:
+  sql-gateway:
+    pgwire:
+      auth:
+        mode: password
+        credential-store: bcrypt   # plaintext | bcrypt
+        users:
+          alice: "$2a$12$..."      # bcrypt hash
+        policies:
+          alice:
+            allowed-schemas: [sales]
+```
+
+---
+
+## Build and test
+
+```bash
+# All tests (from repo root)
+./mvnw verify
+
+# This module only
+./mvnw test -pl skadi-sql-gateway
+
+# Build JAR (skip tests)
+./mvnw package -DskipTests -pl skadi-sql-gateway -am
+```
+
+Tests use real objects — no Mockito mocks. See `src/test/java` for the test suite.
+
+---
+
+## Docker
+
+```bash
+# Build image
+docker build -f skadi-sql-gateway/Dockerfile -t skadi-sql-gateway:latest .
+
+# Run with docker compose (from skadi-sql-gateway/)
+cp .env.example .env   # fill in Databricks credentials
+docker compose up -d
+
+# Verify
+curl -s http://localhost:8090/actuator/health | python3 -m json.tool
+psql -h localhost -p 15432 -U demo postgres -c "SELECT 1"
+```
+
+Full Docker deployment guide: [docs/deployment/docker.md](../docs/deployment/docker.md)
+
+---
+
+## Configuration reference
+
+All settings are under `skadi.sql-gateway.*` in `application.yml`, or as environment
+variables (Spring Boot convention: replace `.` and `-` with `_`, uppercase).
+
+| Key | Env var | Default | Notes |
+|---|---|---|---|
+| `pgwire.enabled` | `SKADI_SQL_GATEWAY_PGWIRE_ENABLED` | `false` | Must be `true` |
+| `pgwire.port` | `SKADI_SQL_GATEWAY_PGWIRE_PORT` | `15432` | |
+| `pgwire.auth.mode` | `SKADI_SQL_GATEWAY_PGWIRE_AUTH_MODE` | `trust` | Use `password` for production |
+| `pgwire.query-timeout` | `SKADI_SQL_GATEWAY_PGWIRE_QUERY_TIMEOUT` | *(none)* | e.g. `5m` |
+| `databricks.enabled` | `SKADI_SQL_GATEWAY_DATABRICKS_ENABLED` | `false` | Must be `true` |
+| `databricks.host` | `SKADI_SQL_GATEWAY_DATABRICKS_HOST` | | Workspace hostname |
+| `databricks.http-path` | `SKADI_SQL_GATEWAY_DATABRICKS_HTTP_PATH` | | Warehouse HTTP path |
+| `databricks.token` | `SKADI_SQL_GATEWAY_DATABRICKS_TOKEN` | | PAT token (keep secret) |
+| `metadata.dbx-catalog` | `SKADI_SQL_GATEWAY_METADATA_DBX_CATALOG` | `main` | Unity Catalog name |
+| `metadata.dbx-schema` | `SKADI_SQL_GATEWAY_METADATA_DBX_SCHEMA` | `public` | Schema to expose |
+| `cache.enabled` | `SKADI_SQL_GATEWAY_CACHE_ENABLED` | `true` | |
+| `cache.ttl` | `SKADI_SQL_GATEWAY_CACHE_TTL` | `5m` | |
+
+---
+
+## Health endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /actuator/health` | Overall health |
+| `GET /actuator/health/pgWire` | pgwire listener readiness (use as k8s readiness probe) |
+| `GET /actuator/prometheus` | Prometheus metrics scrape |
+| `GET /ping` | Simple liveness (`ok`) |
+
+---
+
+## Deployment guides
+
+- [Docker deployment](../docs/deployment/docker.md)
+- [Tableau Server](../docs/deployment/tableau-server.md)
+- [Tableau Bridge / Cloud](../docs/deployment/tableau-bridge.md)
+- [Production checklist](../docs/deployment/production-checklist.md)
+- [Troubleshooting](../docs/deployment/troubleshooting.md)

--- a/skadi-sql-gateway/docker-compose.yml
+++ b/skadi-sql-gateway/docker-compose.yml
@@ -1,0 +1,92 @@
+version: "3.9"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Skadi SQL Gateway — local development / staging compose
+#
+# Usage:
+#   cp .env.example .env        # fill in Databricks credentials
+#   docker compose up -d
+#   psql -h localhost -p 15432 -U demo postgres   # smoke test
+#
+# For a production deployment, see docs/deployment/docker.md
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+
+  skadi-sql-gateway:
+    build:
+      context: ..
+      dockerfile: skadi-sql-gateway/Dockerfile
+    image: skadi-sql-gateway:local
+    container_name: skadi-sql-gateway
+    restart: unless-stopped
+    ports:
+      - "${PGWIRE_PORT:-15432}:15432"   # pgwire (PostgreSQL protocol)
+      - "${HTTP_PORT:-8090}:8090"        # Spring Boot Actuator / HTTP
+    environment:
+      # ── pgwire ───────────────────────────────────────────────────────────
+      SKADI_SQL_GATEWAY_PGWIRE_ENABLED: "true"
+      SKADI_SQL_GATEWAY_PGWIRE_HOST: "0.0.0.0"
+      SKADI_SQL_GATEWAY_PGWIRE_PORT: "15432"
+      SKADI_SQL_GATEWAY_PGWIRE_AUTH_MODE: "${PGWIRE_AUTH_MODE:-trust}"
+      # Uncomment and set for password mode:
+      # SKADI_SQL_GATEWAY_PGWIRE_AUTH_USERS_ALICE: "${ALICE_PASSWORD}"
+      SKADI_SQL_GATEWAY_PGWIRE_QUERY_TIMEOUT: "${QUERY_TIMEOUT:-5m}"
+      SKADI_SQL_GATEWAY_PGWIRE_MAX_CONCURRENT_QUERIES_PER_USER: "${MAX_CONCURRENT:-10}"
+
+      # ── Databricks ───────────────────────────────────────────────────────
+      SKADI_SQL_GATEWAY_DATABRICKS_ENABLED: "${DATABRICKS_ENABLED:-false}"
+      SKADI_SQL_GATEWAY_DATABRICKS_HOST: "${DATABRICKS_HOST:-}"
+      SKADI_SQL_GATEWAY_DATABRICKS_HTTP_PATH: "${DATABRICKS_HTTP_PATH:-}"
+      SKADI_SQL_GATEWAY_DATABRICKS_TOKEN: "${DATABRICKS_TOKEN:-}"
+      SKADI_SQL_GATEWAY_DATABRICKS_MAX_POOL_SIZE: "${DATABRICKS_POOL_SIZE:-5}"
+      SKADI_SQL_GATEWAY_DATABRICKS_QUERY_TIMEOUT: "${DATABRICKS_QUERY_TIMEOUT:-5m}"
+
+      # ── Metadata facade ──────────────────────────────────────────────────
+      SKADI_SQL_GATEWAY_METADATA_ENABLED: "true"
+      SKADI_SQL_GATEWAY_METADATA_PG_DATABASE: "${PG_DATABASE:-postgres}"
+      SKADI_SQL_GATEWAY_METADATA_DBX_CATALOG: "${DBX_CATALOG:-main}"
+      SKADI_SQL_GATEWAY_METADATA_DBX_SCHEMA: "${DBX_SCHEMA:-default}"
+
+      # ── Cache ────────────────────────────────────────────────────────────
+      SKADI_SQL_GATEWAY_CACHE_ENABLED: "${CACHE_ENABLED:-true}"
+      SKADI_SQL_GATEWAY_CACHE_TTL: "${CACHE_TTL:-5m}"
+      SKADI_SQL_GATEWAY_CACHE_MAX_ENTRIES: "${CACHE_MAX_ENTRIES:-500}"
+
+      # ── Observability ────────────────────────────────────────────────────
+      MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: "health,info,metrics,prometheus"
+
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8090/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      start_period: 45s
+      retries: 3
+
+    volumes:
+      # Mount Databricks JDBC driver if available (optional)
+      # - ./drivers:/opt/skadi/drivers:ro
+      # Mount custom application.yml to override defaults (optional)
+      # - ./config/application-local.yml:/app/config/application-local.yml:ro
+      []
+
+  # ── Optional: Prometheus for metrics scraping ─────────────────────────────
+  # Uncomment to enable local Prometheus + Grafana
+  #
+  # prometheus:
+  #   image: prom/prometheus:latest
+  #   container_name: skadi-prometheus
+  #   ports:
+  #     - "9090:9090"
+  #   volumes:
+  #     - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+  #   depends_on:
+  #     - skadi-sql-gateway
+  #
+  # grafana:
+  #   image: grafana/grafana:latest
+  #   container_name: skadi-grafana
+  #   ports:
+  #     - "3000:3000"
+  #   depends_on:
+  #     - prometheus

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/pgwire/PgWireHealthIndicator.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/pgwire/PgWireHealthIndicator.java
@@ -1,0 +1,62 @@
+package org.iceforge.skadi.sqlgateway.pgwire;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring Boot Actuator health indicator for the pgwire listener.
+ *
+ * <p>Contributes to {@code /actuator/health} when pgwire is enabled, reporting:
+ * <ul>
+ *   <li>{@code UP} — listener is bound and accepting connections, with the bound port</li>
+ *   <li>{@code DOWN} — listener failed to start or has not yet bound</li>
+ * </ul>
+ *
+ * <p>This indicator is only registered when {@code skadi.sql-gateway.pgwire.enabled=true},
+ * so health checks in non-pgwire configurations are unaffected.
+ *
+ * <p>Use this indicator as the k8s readiness probe target:
+ * <pre>
+ *   readinessProbe:
+ *     httpGet:
+ *       path: /actuator/health/pgWire
+ *       port: 8090
+ * </pre>
+ */
+@Component("pgWire")
+@ConditionalOnProperty(prefix = "skadi.sql-gateway.pgwire", name = "enabled", havingValue = "true")
+public class PgWireHealthIndicator implements HealthIndicator {
+
+    private final PgWireServerLifecycle lifecycle;
+
+    public PgWireHealthIndicator(PgWireServerLifecycle lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    @Override
+    public Health health() {
+        if (!lifecycle.isRunning()) {
+            return Health.down()
+                    .withDetail("reason", "pgwire disabled or startup failed")
+                    .build();
+        }
+        PgWireServer server = lifecycle.getServer();
+        if (server == null) {
+            return Health.down()
+                    .withDetail("reason", "pgwire server instance unavailable")
+                    .build();
+        }
+        int port = server.getLocalPort();
+        if (port <= 0) {
+            return Health.down()
+                    .withDetail("reason", "pgwire server not yet bound to a port")
+                    .build();
+        }
+        return Health.up()
+                .withDetail("port", port)
+                .withDetail("protocol", "pgwire/PostgreSQL")
+                .build();
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/PgWireHealthIndicatorTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/PgWireHealthIndicatorTest.java
@@ -1,0 +1,86 @@
+package org.iceforge.skadi.sqlgateway.pgwire;
+
+import org.iceforge.skadi.sqlgateway.config.SqlGatewayProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B7 — Verifies that {@link PgWireHealthIndicator} reports correct health status
+ * based on the pgwire server lifecycle state.
+ */
+class PgWireHealthIndicatorTest {
+
+    @Test
+    void reports_up_when_server_is_running() throws Exception {
+        SqlGatewayProperties.PgWire.Auth auth =
+                new SqlGatewayProperties.PgWire.Auth("trust", null, Map.of(), null);
+        SqlGatewayProperties.PgWire props =
+                new SqlGatewayProperties.PgWire(true, "127.0.0.1", 0, auth,
+                        null, null, null, null, null);
+
+        // Create and start a real server so getLocalPort() > 0.
+        try (PgWireServer server = new PgWireServer(props, null, null, null)) {
+            server.start();
+            for (int i = 0; i < 50 && server.getLocalPort() == 0; i++) Thread.sleep(10);
+
+            PgWireServerLifecycle lifecycle = stubLifecycle(props, server);
+            PgWireHealthIndicator indicator = new PgWireHealthIndicator(lifecycle);
+
+            Health health = indicator.health();
+
+            assertThat(health.getStatus()).isEqualTo(Status.UP);
+            assertThat(health.getDetails()).containsKey("port");
+            assertThat((Integer) health.getDetails().get("port")).isGreaterThan(0);
+            assertThat(health.getDetails()).containsEntry("protocol", "pgwire/PostgreSQL");
+        }
+    }
+
+    @Test
+    void reports_down_when_lifecycle_is_not_running() {
+        SqlGatewayProperties.PgWire.Auth auth =
+                new SqlGatewayProperties.PgWire.Auth("trust", null, Map.of(), null);
+        SqlGatewayProperties.PgWire props =
+                new SqlGatewayProperties.PgWire(false, "127.0.0.1", 15432, auth,
+                        null, null, null, null, null);
+
+        // Lifecycle that reports not-running (pgwire.enabled=false).
+        PgWireServerLifecycle lifecycle = new PgWireServerLifecycle(
+                new SqlGatewayProperties(null, null, props, null, null, null));
+        // Do not call lifecycle.start() — simulates disabled state.
+
+        PgWireHealthIndicator indicator = new PgWireHealthIndicator(lifecycle);
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsKey("reason");
+    }
+
+    // --- helpers ---
+
+    /** Wraps a started PgWireServer in a minimal lifecycle stub that reports isRunning=true. */
+    private static PgWireServerLifecycle stubLifecycle(SqlGatewayProperties.PgWire props,
+                                                        PgWireServer server) {
+        SqlGatewayProperties.PgWire enabledProps =
+                new SqlGatewayProperties.PgWire(true, props.host(), props.port(), props.auth(),
+                        null, null, null, null, null);
+        PgWireServerLifecycle lifecycle = new PgWireServerLifecycle(
+                new SqlGatewayProperties(null, null, enabledProps, null, null, null));
+        // Reflectively set the server field so the lifecycle reports the live server.
+        try {
+            java.lang.reflect.Field f = PgWireServerLifecycle.class.getDeclaredField("server");
+            f.setAccessible(true);
+            f.set(lifecycle, server);
+            java.lang.reflect.Field r = PgWireServerLifecycle.class.getDeclaredField("running");
+            r.setAccessible(true);
+            r.set(lifecycle, true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return lifecycle;
+    }
+}


### PR DESCRIPTION
## Summary

- **PgWireHealthIndicator** — `@Component("pgWire")` health indicator registered under `/actuator/health/pgWire`; reports `UP` with port detail once the pgwire listener is bound; used as k8s readiness probe so traffic only reaches the pod after the socket is ready
- **Docker packaging** — multi-stage `Dockerfile` (eclipse-temurin:21-jdk-jammy → 21-jre-jammy), non-root `skadi` user, `docker-compose.yml` with full env-var mapping and commented Prometheus/Grafana services
- **Deployment documentation** — `docs/deployment/`: README, `docker.md` (build, compose, docker run, JDBC driver options, TLS proxy examples, k8s manifest), `tableau-server.md`, `tableau-bridge.md`, `production-checklist.md`, `troubleshooting.md`
- **Smoke test script** — `scripts/smoke-test.sh` checks HTTP health, pgwire connectivity, metadata facade, and optional real Databricks query; exits 0/1 for CI use
- **Module README** — `skadi-sql-gateway/README.md` rewritten with quick start, auth modes, config reference table, health endpoints, and deployment guide links

## Test plan

- [ ] `./mvnw test -pl skadi-sql-gateway` — 201 tests pass (2 new: `PgWireHealthIndicatorTest`)
- [ ] `curl http://localhost:8090/actuator/health/pgWire` returns `{"status":"UP","details":{"port":15432,"protocol":"pgwire/PostgreSQL"}}`
- [ ] `docker build -f skadi-sql-gateway/Dockerfile -t skadi-sql-gateway:latest .` completes without error
- [ ] `cd skadi-sql-gateway && docker compose up -d` starts healthy container
- [ ] `./scripts/smoke-test.sh` exits 0 against a running gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)