### PR TITLE
Normalize repository line endings before Lane C

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,48 @@
-/mvnw text eol=lf
-*.cmd text eol=crlf
+# Default: auto-detect text files and normalize to LF on check-in
+* text=auto eol=lf
+
+# --- Source ---
+*.java       text eol=lf
+*.xml        text eol=lf
+*.yml        text eol=lf
+*.yaml       text eol=lf
+*.json       text eol=lf
+*.md         text eol=lf
+*.sh         text eol=lf
+*.properties text eol=lf
+*.html       text eol=lf
+*.css        text eol=lf
+*.tsx        text eol=lf
+*.ts         text eol=lf
+*.sql        text eol=lf
+*.txt        text eol=lf
+
+# --- Config / meta ---
+.gitignore     text eol=lf
+.gitattributes text eol=lf
+Makefile       text eol=lf
+Dockerfile     text eol=lf
+LICENSE        text eol=lf
+/mvnw          text eol=lf
+*.config       text eol=lf
+
+# --- Windows scripts — keep CRLF ---
+*.cmd  text eol=crlf
+*.bat  text eol=crlf
+*.ps1  text eol=crlf
+
+# --- Binary — no line-ending conversion ---
+*.jar      binary
+*.class    binary
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.ico      binary
+*.zip      binary
+*.tar      binary
+*.gz       binary
+*.p12      binary
+*.jks      binary
+*.keystore binary
+deps.lock  binary


### PR DESCRIPTION
## Summary

- Adds comprehensive `.gitattributes` rules: `* text=auto eol=lf` catch-all plus explicit per-type rules for every tracked text extension
- `*.cmd` / `*.bat` / `*.ps1` remain `eol=crlf` (Windows scripts)
- `deps.lock` (UTF-16 LE file) and all archive/image/keystore types marked `binary` to prevent corruption
- Ran `git add --renormalize .` to flush the index — all 179 CRLF working-tree noise diffs are eliminated

## Why now

The Windows/WSL2 checkout environment wrote CRLF to the `/mnt/c/` filesystem. Without an explicit `.gitattributes` policy, `git status` showed 179 spurious modifications on every session. This is a pre-Lane-C hygiene fix to eliminate that noise permanently.

## Test plan

- [x] `git status` shows zero modified files after renormalization (only `.gitattributes` in this commit)
- [x] `./mvnw verify -pl skadi-sql-gateway -am` → 232 tests, 0 failures, BUILD SUCCESS
- [x] `deps.lock` (UTF-16 LE) is marked binary — not touched by normalization
- [x] `mvnw` retains `eol=lf` (was already set; preserved under new explicit rule)
- [x] `*.cmd` retains `eol=crlf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)