### PR TITLE
Normalize repository line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,48 @@
-/mvnw text eol=lf
-*.cmd text eol=crlf
+# Default: auto-detect text files and normalize to LF on check-in
+* text=auto eol=lf
+
+# --- Source ---
+*.java       text eol=lf
+*.xml        text eol=lf
+*.yml        text eol=lf
+*.yaml       text eol=lf
+*.json       text eol=lf
+*.md         text eol=lf
+*.sh         text eol=lf
+*.properties text eol=lf
+*.html       text eol=lf
+*.css        text eol=lf
+*.tsx        text eol=lf
+*.ts         text eol=lf
+*.sql        text eol=lf
+*.txt        text eol=lf
+
+# --- Config / meta ---
+.gitignore     text eol=lf
+.gitattributes text eol=lf
+Makefile       text eol=lf
+Dockerfile     text eol=lf
+LICENSE        text eol=lf
+/mvnw          text eol=lf
+*.config       text eol=lf
+
+# --- Windows scripts — keep CRLF ---
+*.cmd  text eol=crlf
+*.bat  text eol=crlf
+*.ps1  text eol=crlf
+
+# --- Binary — no line-ending conversion ---
+*.jar      binary
+*.class    binary
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.ico      binary
+*.zip      binary
+*.tar      binary
+*.gz       binary
+*.p12      binary
+*.jks      binary
+*.keystore binary
+deps.lock  binary


### PR DESCRIPTION
## Summary

Normalizes repository line-ending behavior via .gitattributes.

This branch was recreated from current main to avoid regressing newer semantic-layer work.

## Validation

- Ran full Maven reactor build successfully:

```bash
./mvnw verify
```

- Build included:
  - skadi-core
  - skadi-semantic
  - skadi-server
  - skadi-sql-gateway

## Notes

This PR should only affect .gitattributes / line-ending policy and should not remove or modify Lane C, Lane D, semantic module, ADR, or DQR artifacts.