### PR TITLE
Implement Tableau SQL Endpoint B8 MySQL wire-protocol endpoint skadi#30

### DIFF
--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -1,9 +1,9 @@
 # Skadi — Development Status
 
 > Updated: 2026-05-12
-> Branch: `feature/tableau-sql-endpoint-b7-deployment-readiness` → PR #35
+> Branch: `feature/tableau-sql-endpoint-b8-mysql-wire` → PR #36
 > Last commit: pending push
-> Build: ✅ 201 tests passing
+> Build: ✅ 232 tests passing
 
 ---
 
@@ -34,7 +34,39 @@
 | B5 | Observability — production-grade | ✅ Done | `d2c7f7a` (PR #33) | Prometheus endpoint, Micrometer timers, session gauge, correlation IDs |
 | B6 | Security hardening — TLS, redaction, audit log | ✅ Done | `287740e` (PR #34) | SecretRedactor, SqlSecurityValidator, AuditLog, require-ssl enforcement |
 | B7 | Tableau Server / Cloud deployment readiness | ✅ Done | pending (PR #35) | Dockerfile, docker-compose, health indicator, full deployment docs |
-| B8 | MySQL wire-protocol endpoint (optional) | ❌ Not started | — | Dialect translator exists |
+| B8 | MySQL wire-protocol endpoint (optional) | ✅ Done | pending (PR #36) | MySqlWireServer, COM_QUERY, mysql_native_password auth; 31 new tests |
+
+---
+
+## B8 Implementation Summary
+
+**Issue:** #30 (to be closed)
+
+### New package: `mysqwire`
+- `MySqlWireServer` — TCP server; accepts connections, spawns `MySqlWireSession` per client
+- `MySqlWireSession` — MySQL Handshake v10, `mysql_native_password` challenge-response auth, COM_QUERY text protocol, COM_PING, COM_QUIT, COM_INIT_DB
+- `MySqlWireServerLifecycle` — `SmartLifecycle` Spring component; mirrors `PgWireServerLifecycle`
+- `MySqlWireHealthIndicator` — `@Component("mySqlWire")` for `/actuator/health/mySqlWire`; gated by `skadi.sql-gateway.mysqlwire.enabled=true`
+- `MySqlExecutorProviderHolder` / `MySqlExecutorProviderWiring` — static bridge for shared Databricks DataSource
+- `JdbcToMySqlTypeMapper` — JDBC type → MySQL column type codes, flags, display widths
+
+### Protocol scope
+- Handshake v10: server greeting with random 20-byte challenge, capability flags, auth plugin name
+- `mysql_native_password`: SHA1(password) XOR SHA1(challenge + SHA1(SHA1(password))); verified server-side from plaintext or trust-mode
+- COM_QUERY: SQL routed through `SqlDialectBridge` (MYSQL dialect) → metadata facade → JDBC executor → MySQL result set (column count, column def ×N, EOF, row data ×N, EOF)
+- Trust mode: accepts any username/password; password mode: validates challenge-response
+
+### Config
+- `SqlGatewayProperties.MySqlWire` record added (7th field in `SqlGatewayProperties`)
+- `SqlDialectBridgeOptions.defaultForMySqlWire()` factory added
+- `application.yml`: `skadi.sql-gateway.mysqlwire.enabled=false` (port 13306)
+
+### Tests added (31 total)
+- `MySqlHandshakeTest` (4): greeting packet structure, unique connection IDs, trust auth, password rejection
+- `MySqlNativePasswordTest` (5): correct password verifies, wrong fails, empty/null token, different challenges
+- `MySqlQueryRoutingTest` (6): SELECT 1, multi-row result, row value encoding, COM_PING, metadata facade, unsupported command ERR
+- `MySqlTypeMapperTest` (14): JDBC → MySQL type codes, flags, display lengths
+- `MySqlWireHealthIndicatorTest` (2): UP when running, DOWN when disabled
 
 ---
 

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/config/SqlGatewayProperties.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/config/SqlGatewayProperties.java
@@ -18,7 +18,8 @@ public record SqlGatewayProperties(
         PgWire pgwire,
         Metadata metadata,
         Cache cache,
-        Trace trace
+        Trace trace,
+        MySqlWire mysqlwire
 ) {
 
     public record PgWire(
@@ -107,6 +108,31 @@ public record SqlGatewayProperties(
     ) {
         public boolean isEnabled() {
             return enabled;
+        }
+    }
+
+    /**
+     * MySQL wire-protocol endpoint configuration (B8 — optional).
+     *
+     * <p>Shares the same execution core (dialect bridge, executor, cache) as the pgwire endpoint.
+     * Auth model is identical: trust (accept all) or password (validate via challenge-response).
+     */
+    public record MySqlWire(
+            boolean enabled,
+            String host,
+            int port,
+            PgWire.Auth auth,
+            Duration queryTimeout,
+            Integer maxConcurrentQueriesPerUser
+    ) {
+        public Duration effectiveQueryTimeout() {
+            return (queryTimeout == null || queryTimeout.isNegative() || queryTimeout.isZero())
+                    ? null : queryTimeout;
+        }
+
+        public int effectiveMaxConcurrentQueriesPerUser() {
+            return (maxConcurrentQueriesPerUser == null || maxConcurrentQueriesPerUser <= 0)
+                    ? 0 : maxConcurrentQueriesPerUser;
         }
     }
 

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/dialect/SqlDialectBridgeOptions.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/dialect/SqlDialectBridgeOptions.java
@@ -29,4 +29,17 @@ public record SqlDialectBridgeOptions(
                 true
         );
     }
+
+    public static SqlDialectBridgeOptions defaultForMySqlWire() {
+        return new SqlDialectBridgeOptions(
+                SourceDialect.MYSQL,
+                ClientCompatibility.GENERIC_JDBC,
+                true,
+                true,
+                false, // no PG-style ::casts to rewrite
+                true,
+                true,
+                true
+        );
+    }
 }

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/JdbcToMySqlTypeMapper.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/JdbcToMySqlTypeMapper.java
@@ -1,0 +1,71 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import java.sql.Types;
+
+/** Maps JDBC column types to MySQL wire-protocol type codes. */
+final class JdbcToMySqlTypeMapper {
+    // MySQL type codes (subset used for result set column definitions)
+    static final int MYSQL_TYPE_TINY      = 1;
+    static final int MYSQL_TYPE_SHORT     = 2;
+    static final int MYSQL_TYPE_LONG      = 3;
+    static final int MYSQL_TYPE_FLOAT     = 4;
+    static final int MYSQL_TYPE_DOUBLE    = 5;
+    static final int MYSQL_TYPE_TIMESTAMP = 7;
+    static final int MYSQL_TYPE_LONGLONG  = 8;
+    static final int MYSQL_TYPE_DATE      = 10;
+    static final int MYSQL_TYPE_DATETIME  = 12;
+    static final int MYSQL_TYPE_BLOB      = 252;
+    static final int MYSQL_TYPE_VAR_STRING = 253;
+    static final int MYSQL_TYPE_STRING    = 254;
+    static final int MYSQL_TYPE_NEWDECIMAL = 246;
+
+    // MySQL column flags
+    static final int FLAG_NOT_NULL     = 0x0001;
+    static final int FLAG_BINARY       = 0x0080;
+    static final int FLAG_NUM          = 0x8000;
+
+    private JdbcToMySqlTypeMapper() {}
+
+    static int toMySqlType(int jdbcType) {
+        return switch (jdbcType) {
+            case Types.BIGINT                      -> MYSQL_TYPE_LONGLONG;
+            case Types.INTEGER                     -> MYSQL_TYPE_LONG;
+            case Types.SMALLINT, Types.TINYINT     -> MYSQL_TYPE_SHORT;
+            case Types.DOUBLE                      -> MYSQL_TYPE_DOUBLE;
+            case Types.FLOAT, Types.REAL           -> MYSQL_TYPE_FLOAT;
+            case Types.DECIMAL, Types.NUMERIC      -> MYSQL_TYPE_NEWDECIMAL;
+            case Types.BOOLEAN, Types.BIT          -> MYSQL_TYPE_TINY;
+            case Types.DATE                        -> MYSQL_TYPE_DATE;
+            case Types.TIMESTAMP,
+                 Types.TIMESTAMP_WITH_TIMEZONE     -> MYSQL_TYPE_DATETIME;
+            case Types.CLOB, Types.NCLOB,
+                 Types.LONGVARCHAR, Types.LONGNVARCHAR -> MYSQL_TYPE_BLOB;
+            default                                -> MYSQL_TYPE_VAR_STRING;
+        };
+    }
+
+    static int flagsFor(int jdbcType) {
+        return switch (jdbcType) {
+            case Types.BIGINT, Types.INTEGER, Types.SMALLINT, Types.TINYINT,
+                 Types.DOUBLE, Types.FLOAT, Types.REAL, Types.DECIMAL, Types.NUMERIC,
+                 Types.BOOLEAN, Types.BIT -> FLAG_NUM;
+            default -> 0;
+        };
+    }
+
+    static int displayLen(int jdbcType, int precision) {
+        if (precision > 0) return precision;
+        return switch (jdbcType) {
+            case Types.BIGINT    -> 20;
+            case Types.INTEGER   -> 11;
+            case Types.SMALLINT  -> 6;
+            case Types.TINYINT   -> 4;
+            case Types.DOUBLE    -> 22;
+            case Types.FLOAT     -> 12;
+            case Types.BOOLEAN   -> 1;
+            case Types.DATE      -> 10;
+            case Types.TIMESTAMP -> 19;
+            default              -> 255;
+        };
+    }
+}

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlExecutorProviderHolder.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlExecutorProviderHolder.java
@@ -1,0 +1,18 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.iceforge.skadi.sqlgateway.pgwire.SqlExecutorProvider;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Static bridge giving manually-constructed {@link MySqlWireSession} access to the
+ * shared JDBC executor — mirrors the pattern used in the pgwire layer.
+ */
+final class MySqlExecutorProviderHolder {
+    private static final AtomicReference<SqlExecutorProvider> REF = new AtomicReference<>();
+
+    private MySqlExecutorProviderHolder() {}
+
+    static SqlExecutorProvider get() { return REF.get(); }
+    static void set(SqlExecutorProvider p) { REF.set(p); }
+}

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlExecutorProviderWiring.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlExecutorProviderWiring.java
@@ -1,0 +1,19 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+/**
+ * Wires the shared Databricks {@link DataSource} into the MySQL wire layer.
+ * Mirrors the pgwire {@code SqlExecutorProviderWiring} pattern.
+ */
+@Configuration
+@ConditionalOnBean(name = "databricksDataSource")
+class MySqlExecutorProviderWiring {
+
+    MySqlExecutorProviderWiring(DataSource dataSource) {
+        MySqlExecutorProviderHolder.set(dataSource::getConnection);
+    }
+}

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireHealthIndicator.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireHealthIndicator.java
@@ -1,0 +1,43 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Reports the MySQL wire server's readiness under {@code /actuator/health/mySqlWire}.
+ *
+ * <p>Active only when {@code skadi.sql-gateway.mysqlwire.enabled=true}.
+ */
+@Component("mySqlWire")
+@ConditionalOnProperty(prefix = "skadi.sql-gateway.mysqlwire", name = "enabled", havingValue = "true")
+public class MySqlWireHealthIndicator implements HealthIndicator {
+
+    private final MySqlWireServerLifecycle lifecycle;
+
+    public MySqlWireHealthIndicator(MySqlWireServerLifecycle lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    @Override
+    public Health health() {
+        if (!lifecycle.isRunning()) {
+            return Health.down()
+                    .withDetail("reason", "mysql wire server disabled or startup failed")
+                    .build();
+        }
+        MySqlWireServer server = lifecycle.getServer();
+        if (server == null) {
+            return Health.down().withDetail("reason", "server not initialised").build();
+        }
+        int port = server.getLocalPort();
+        if (port <= 0) {
+            return Health.down().withDetail("reason", "server not yet bound").build();
+        }
+        return Health.up()
+                .withDetail("port", port)
+                .withDetail("protocol", "mysql/MySQL-wire")
+                .build();
+    }
+}

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireServer.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireServer.java
@@ -1,0 +1,84 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.iceforge.skadi.sqlgateway.config.SqlGatewayProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/** MySQL wire-protocol TCP server. Accepts connections and spawns {@link MySqlWireSession}s. */
+public class MySqlWireServer implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(MySqlWireServer.class);
+
+    private final SqlGatewayProperties.MySqlWire props;
+    private final SqlGatewayProperties.Metadata metadataProps;
+
+    private final ExecutorService acceptor = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "mysql-acceptor");
+        t.setDaemon(true);
+        return t;
+    });
+    private final ExecutorService sessions = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r, "mysql-session");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private volatile boolean running;
+    private volatile ServerSocket serverSocket;
+    private volatile int localPort;
+
+    public MySqlWireServer(SqlGatewayProperties.MySqlWire props,
+                           SqlGatewayProperties.Metadata metadataProps) {
+        this.props = Objects.requireNonNull(props, "props");
+        this.metadataProps = metadataProps;
+    }
+
+    public void start() throws IOException {
+        if (running) return;
+        running = true;
+
+        InetAddress bind = InetAddress.getByName(props.host());
+        ServerSocket ss = new ServerSocket(props.port(), 50, bind);
+        ss.setSoTimeout((int) Duration.ofSeconds(1).toMillis());
+        this.serverSocket = ss;
+        this.localPort = ss.getLocalPort();
+
+        log.info("MySQL wire server listening on {}:{} (authMode={})",
+                props.host(), this.localPort,
+                props.auth() == null ? "trust" : props.auth().mode());
+
+        acceptor.submit(() -> {
+            while (running) {
+                try {
+                    Socket client = ss.accept();
+                    sessions.submit(new MySqlWireSession(client, props, metadataProps));
+                } catch (java.net.SocketTimeoutException ignored) {
+                    // loop to check running flag
+                } catch (IOException e) {
+                    if (running) log.warn("mysql accept error: {}", e.getMessage());
+                }
+            }
+        });
+    }
+
+    public int getLocalPort() { return localPort; }
+
+    @Override
+    public void close() {
+        running = false;
+        ServerSocket ss = serverSocket;
+        if (ss != null) {
+            try { ss.close(); } catch (IOException ignored) {}
+        }
+        acceptor.shutdownNow();
+        sessions.shutdownNow();
+    }
+}

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireServerLifecycle.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireServerLifecycle.java
@@ -1,0 +1,56 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.iceforge.skadi.sqlgateway.config.SqlGatewayProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Objects;
+
+@Component
+public class MySqlWireServerLifecycle implements SmartLifecycle {
+    private static final Logger log = LoggerFactory.getLogger(MySqlWireServerLifecycle.class);
+
+    private final SqlGatewayProperties props;
+    private volatile MySqlWireServer server;
+    private volatile boolean running;
+
+    public MySqlWireServerLifecycle(SqlGatewayProperties props) {
+        this.props = Objects.requireNonNull(props, "props");
+    }
+
+    @Override
+    public void start() {
+        SqlGatewayProperties.MySqlWire mysql = props.mysqlwire();
+        if (mysql == null || !mysql.enabled()) {
+            log.info("MySQL wire server disabled");
+            return;
+        }
+
+        try {
+            MySqlWireServer s = new MySqlWireServer(mysql, props.metadata());
+            s.start();
+            this.server = s;
+            this.running = true;
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to start MySQL wire server", e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        this.running = false;
+        MySqlWireServer s = this.server;
+        if (s != null) s.close();
+    }
+
+    @Override
+    public boolean isRunning() { return running; }
+
+    @Override
+    public int getPhase() { return 0; }
+
+    public MySqlWireServer getServer() { return server; }
+}

--- a/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireSession.java
+++ b/skadi-sql-gateway/src/main/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireSession.java
@@ -1,0 +1,529 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.iceforge.skadi.sqlgateway.auth.AuthProvider;
+import org.iceforge.skadi.sqlgateway.auth.AuthProviderFactory;
+import org.iceforge.skadi.sqlgateway.config.SqlGatewayProperties;
+import org.iceforge.skadi.sqlgateway.dialect.SqlDialectBridge;
+import org.iceforge.skadi.sqlgateway.dialect.SqlDialectBridgeOptions;
+import org.iceforge.skadi.sqlgateway.dialect.SqlDialectBridgeResult;
+import org.iceforge.skadi.sqlgateway.metadata.MetadataCache;
+import org.iceforge.skadi.sqlgateway.metadata.MetadataQueryRouter;
+import org.iceforge.skadi.sqlgateway.metadata.MetadataRowSet;
+import org.iceforge.skadi.sqlgateway.pgwire.SqlExecutorProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.sql.Types;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Handles one MySQL wire-protocol client connection.
+ *
+ * <p>Protocol scope: Handshake v10, mysql_native_password auth, COM_QUERY text protocol.
+ * Prepared statements (COM_STMT_*) are not implemented — this covers the DBeaver / Workbench
+ * "simple" connection mode and any client that uses the text protocol.
+ */
+final class MySqlWireSession implements Runnable {
+    private static final Logger log = LoggerFactory.getLogger(MySqlWireSession.class);
+
+    private static final MetadataCache METADATA_CACHE = new MetadataCache(Clock.systemUTC());
+
+    // MySQL capability flags
+    private static final int CAP_LONG_PASSWORD       = 0x00000001;
+    private static final int CAP_LONG_FLAG           = 0x00000004;
+    private static final int CAP_CONNECT_WITH_DB     = 0x00000008;
+    private static final int CAP_PROTOCOL_41         = 0x00000200;
+    private static final int CAP_TRANSACTIONS        = 0x00002000;
+    private static final int CAP_SECURE_CONNECTION   = 0x00008000;
+    private static final int CAP_MULTI_RESULTS       = 0x00020000;
+    private static final int CAP_PLUGIN_AUTH         = 0x00080000;
+    private static final int SERVER_CAPS =
+            CAP_LONG_PASSWORD | CAP_LONG_FLAG | CAP_CONNECT_WITH_DB |
+            CAP_PROTOCOL_41 | CAP_TRANSACTIONS | CAP_SECURE_CONNECTION |
+            CAP_MULTI_RESULTS | CAP_PLUGIN_AUTH;
+
+    private static final int STATUS_AUTOCOMMIT       = 0x0002;
+    private static final byte CHARSET_UTF8           = 0x21;
+
+    // MySQL command bytes
+    private static final int COM_QUIT    = 0x01;
+    private static final int COM_INIT_DB = 0x02;
+    private static final int COM_QUERY   = 0x03;
+    private static final int COM_PING    = 0x0e;
+
+    private static final String AUTH_PLUGIN = "mysql_native_password";
+    private static final String SERVER_VERSION = "8.0.32-skadi";
+
+    private static final AtomicInteger ID_SEQ = new AtomicInteger(1);
+
+    private final Socket socket;
+    private final SqlGatewayProperties.MySqlWire props;
+    private final SqlGatewayProperties.Metadata metadataProps;
+    private final AuthProvider authProvider;
+    private final String sessionId;
+    private final int connectionId;
+    private final MetadataQueryRouter metadata;
+
+    MySqlWireSession(Socket socket,
+                     SqlGatewayProperties.MySqlWire props,
+                     SqlGatewayProperties.Metadata metadataProps) {
+        this.socket = socket;
+        this.props = props;
+        this.metadataProps = metadataProps;
+        this.authProvider = AuthProviderFactory.create(props.auth());
+        this.sessionId = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        this.connectionId = ID_SEQ.getAndIncrement();
+
+        Duration metaTtl = (metadataProps != null && metadataProps.ttl() != null)
+                ? metadataProps.ttl() : Duration.ofMinutes(2);
+        String pgDb = nonBlank(metadataProps != null ? metadataProps.pgDatabase() : null, "mysql");
+        String catalog = nonBlank(metadataProps != null ? metadataProps.dbxCatalog() : null, "main");
+        String schema = nonBlank(metadataProps != null ? metadataProps.dbxSchema() : null, "public");
+        this.metadata = new MetadataQueryRouter(METADATA_CACHE, metaTtl, pgDb, catalog, schema);
+    }
+
+    @Override
+    public void run() {
+        MDC.put("session_id", sessionId);
+        MDC.put("client", socket.getRemoteSocketAddress().toString());
+        try (socket;
+             DataInputStream in = new DataInputStream(new BufferedInputStream(socket.getInputStream()));
+             DataOutputStream out = new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()))) {
+
+            byte[] challenge = randomBytes(20);
+            sendGreeting(out, challenge);
+
+            String user = authenticate(in, out, challenge);
+            if (user == null) return; // auth failed; error already sent
+
+            log.info("mysql session authenticated user={}", user);
+            commandLoop(in, out, user);
+
+        } catch (EOFException e) {
+            log.debug("mysql client disconnected");
+        } catch (IOException e) {
+            log.debug("mysql session I/O error: {}", e.getMessage());
+        } catch (Exception e) {
+            log.warn("mysql session error", e);
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    // ── Handshake ─────────────────────────────────────────────────────────────
+
+    private void sendGreeting(DataOutputStream out, byte[] challenge) throws IOException {
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+
+        // Protocol version 10
+        body.write(10);
+        // Server version
+        writeNullString(body, SERVER_VERSION);
+        // Connection ID (4 bytes LE)
+        writeInt4LE(body, connectionId);
+        // Auth plugin data part 1 (first 8 bytes of challenge)
+        body.write(challenge, 0, 8);
+        // Filler
+        body.write(0);
+        // Capability flags (lower 2 bytes)
+        writeInt2LE(body, SERVER_CAPS & 0xFFFF);
+        // Character set
+        body.write(CHARSET_UTF8);
+        // Status flags
+        writeInt2LE(body, STATUS_AUTOCOMMIT);
+        // Capability flags (upper 2 bytes)
+        writeInt2LE(body, (SERVER_CAPS >> 16) & 0xFFFF);
+        // Auth plugin data length = 21 (total challenge length + 1)
+        body.write(21);
+        // Reserved (10 zeros)
+        body.write(new byte[10]);
+        // Auth plugin data part 2 (remaining 12 bytes + 1 null)
+        body.write(challenge, 8, 12);
+        body.write(0);
+        // Auth plugin name
+        writeNullString(body, AUTH_PLUGIN);
+
+        writePacket(out, 0, body.toByteArray());
+        out.flush();
+    }
+
+    /** Returns the authenticated username, or null if auth failed (error already written). */
+    private String authenticate(DataInputStream in, DataOutputStream out, byte[] challenge)
+            throws Exception {
+        byte[] pktData = readPacket(in); // client handshake response, seq=1
+
+        int offset = 0;
+        int clientCaps = readInt4LE(pktData, offset); offset += 4;
+        /* maxPacketSize = */ readInt4LE(pktData, offset); offset += 4;
+        @SuppressWarnings("unused") int charset = pktData[offset++] & 0xFF;
+        offset += 23; // reserved
+
+        String username = readNullString(pktData, offset);
+        offset += username.length() + 1;
+
+        // Auth response: length-encoded
+        int authLen = pktData[offset++] & 0xFF;
+        byte[] authResponse = Arrays.copyOfRange(pktData, offset, offset + authLen);
+        offset += authLen;
+
+        boolean trusted = "trust".equalsIgnoreCase(props.auth() == null ? "trust" : props.auth().mode());
+        boolean ok;
+        if (trusted) {
+            ok = true;
+        } else {
+            String stored = (props.auth().users() == null) ? null : props.auth().users().get(username);
+            if (stored == null) {
+                ok = false;
+            } else {
+                ok = verifyNativePassword(challenge, stored.getBytes(StandardCharsets.UTF_8), authResponse);
+            }
+        }
+
+        if (!ok) {
+            log.warn("mysql auth failed for user={}", username);
+            sendError(out, 2, 1045, "28000", "Access denied for user '" + username + "'");
+            return null;
+        }
+
+        sendOk(out, 2);
+        return username;
+    }
+
+    // ── Command loop ──────────────────────────────────────────────────────────
+
+    private void commandLoop(DataInputStream in, DataOutputStream out, String user) throws Exception {
+        while (true) {
+            byte[] pktData = readPacket(in);
+            if (pktData.length == 0) {
+                sendOk(out, 1);
+                continue;
+            }
+
+            int cmd = pktData[0] & 0xFF;
+            switch (cmd) {
+                case COM_QUIT -> { return; }
+                case COM_PING -> sendOk(out, 1);
+                case COM_INIT_DB -> {
+                    // USE <db> — acknowledge, don't change routing
+                    sendOk(out, 1);
+                }
+                case COM_QUERY -> {
+                    String sql = new String(pktData, 1, pktData.length - 1, StandardCharsets.UTF_8).trim();
+                    handleQuery(out, sql, user);
+                }
+                default -> sendError(out, 1, 1047, "08S01",
+                        "Command 0x%02x not supported".formatted(cmd));
+            }
+        }
+    }
+
+    private void handleQuery(DataOutputStream out, String sql, String user) throws Exception {
+        log.debug("mysql COM_QUERY user={} sql_len={}", user, sql.length());
+
+        // Metadata facade intercept
+        var metaOpt = metadata.tryAnswer(sql);
+        if (metaOpt.isPresent()) {
+            sendMetadataResultSet(out, metaOpt.get());
+            return;
+        }
+
+        // Dialect bridge (MySQL → Databricks)
+        SqlDialectBridge bridge = new SqlDialectBridge(SqlDialectBridgeOptions.defaultForMySqlWire());
+        SqlDialectBridgeResult bridged = bridge.bridge(sql, List.of());
+
+        SqlExecutorProvider provider = MySqlExecutorProviderHolder.get();
+        if (provider == null) {
+            sendError(out, 1, 1105, "HY000", "No backend executor configured");
+            return;
+        }
+
+        try (Connection conn = provider.getConnection();
+             Statement stmt = conn.createStatement()) {
+
+            Duration timeout = props.effectiveQueryTimeout();
+            if (timeout != null) stmt.setQueryTimeout((int) timeout.toSeconds());
+
+            boolean hasResultSet = stmt.execute(bridged.translatedSql());
+            if (hasResultSet) {
+                try (ResultSet rs = stmt.getResultSet()) {
+                    sendResultSet(out, rs);
+                }
+            } else {
+                sendOk(out, 1);
+            }
+        } catch (Exception e) {
+            log.warn("mysql query error: {}", e.getMessage());
+            sendError(out, 1, 1105, "HY000", e.getMessage() != null ? e.getMessage() : "Query error");
+        }
+    }
+
+    // ── Result set serialisation ──────────────────────────────────────────────
+
+    private void sendMetadataResultSet(DataOutputStream out, MetadataRowSet rs) throws IOException {
+        List<String> cols = rs.columns();
+        List<List<String>> rows = rs.rows();
+
+        int seq = 1;
+
+        // Column count
+        writePacket(out, seq++, encodeLengthInt(cols.size()));
+
+        // Column definitions
+        for (String col : cols) {
+            writePacket(out, seq++, encodeColumnDef(col, JdbcToMySqlTypeMapper.MYSQL_TYPE_VAR_STRING, 0, 255));
+        }
+
+        // EOF after column defs
+        writePacket(out, seq++, eofPacket());
+
+        // Rows
+        for (List<String> row : rows) {
+            ByteArrayOutputStream rowBuf = new ByteArrayOutputStream();
+            for (String val : row) {
+                if (val == null) {
+                    rowBuf.write(0xfb); // NULL marker
+                } else {
+                    byte[] bytes = val.getBytes(StandardCharsets.UTF_8);
+                    writeLengthEncodedBytes(rowBuf, bytes);
+                }
+            }
+            writePacket(out, seq++, rowBuf.toByteArray());
+        }
+
+        // EOF at end
+        writePacket(out, seq, eofPacket());
+        out.flush();
+    }
+
+    private void sendResultSet(DataOutputStream out, ResultSet rs) throws Exception {
+        ResultSetMetaData md = rs.getMetaData();
+        int colCount = md.getColumnCount();
+
+        int seq = 1;
+
+        // Column count
+        writePacket(out, seq++, encodeLengthInt(colCount));
+
+        // Column definitions
+        for (int i = 1; i <= colCount; i++) {
+            int jdbcType = md.getColumnType(i);
+            int mysqlType = JdbcToMySqlTypeMapper.toMySqlType(jdbcType);
+            int flags = JdbcToMySqlTypeMapper.flagsFor(jdbcType);
+            int precision = md.getPrecision(i);
+            int displayLen = JdbcToMySqlTypeMapper.displayLen(jdbcType, precision);
+            writePacket(out, seq++, encodeColumnDef(md.getColumnLabel(i), mysqlType, flags, displayLen));
+        }
+
+        // EOF after column defs
+        writePacket(out, seq++, eofPacket());
+
+        // Rows
+        while (rs.next()) {
+            ByteArrayOutputStream rowBuf = new ByteArrayOutputStream();
+            for (int i = 1; i <= colCount; i++) {
+                Object val = rs.getObject(i);
+                if (val == null || rs.wasNull()) {
+                    rowBuf.write(0xfb);
+                } else {
+                    byte[] bytes = renderValue(val, md.getColumnType(i)).getBytes(StandardCharsets.UTF_8);
+                    writeLengthEncodedBytes(rowBuf, bytes);
+                }
+            }
+            writePacket(out, seq++, rowBuf.toByteArray());
+        }
+
+        // EOF at end
+        writePacket(out, seq, eofPacket());
+        out.flush();
+    }
+
+    private static String renderValue(Object val, int jdbcType) {
+        if (val instanceof java.sql.Timestamp ts) {
+            return ts.toLocalDateTime().toString().replace('T', ' ');
+        }
+        if (val instanceof java.sql.Date d) {
+            return d.toLocalDate().toString();
+        }
+        return val.toString();
+    }
+
+    // ── Packet encoding helpers ───────────────────────────────────────────────
+
+    private static byte[] encodeColumnDef(String name, int mysqlType, int flags, int displayLen) {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        try {
+            writeNullString(b, "def");   // catalog
+            writeNullString(b, "");      // schema
+            writeNullString(b, "");      // table
+            writeNullString(b, "");      // org_table
+            writeNullString(b, name);    // name
+            writeNullString(b, name);    // org_name
+            b.write(0x0c);               // fixed-length fields marker
+            writeInt2LE(b, CHARSET_UTF8 & 0xFF); // character set
+            writeInt4LE(b, displayLen);  // column length
+            b.write(mysqlType);          // type
+            writeInt2LE(b, flags);       // flags
+            b.write(0);                  // decimals
+            b.write(0); b.write(0);      // filler
+        } catch (IOException ignored) { /* ByteArrayOutputStream never throws */ }
+        return b.toByteArray();
+    }
+
+    private static byte[] eofPacket() {
+        // 0xfe + 2 bytes warnings + 2 bytes status
+        return new byte[] { (byte) 0xfe, 0x00, 0x00, 0x02, 0x00 };
+    }
+
+    private static byte[] encodeLengthInt(int val) {
+        if (val < 251) return new byte[] { (byte) val };
+        if (val < 65536) return new byte[] { (byte) 0xfc, (byte) val, (byte) (val >> 8) };
+        return new byte[] { (byte) 0xfd, (byte) val, (byte) (val >> 8), (byte) (val >> 16) };
+    }
+
+    private static void writeLengthEncodedBytes(OutputStream out, byte[] bytes) throws IOException {
+        byte[] lenPfx = encodeLengthInt(bytes.length);
+        out.write(lenPfx);
+        out.write(bytes);
+    }
+
+    private void sendOk(DataOutputStream out, int seq) throws IOException {
+        // OK: 0x00, affected_rows=0, last_insert_id=0, status, warnings
+        writePacket(out, seq, new byte[] { 0x00, 0x00, 0x00, 0x02, 0x00 });
+        out.flush();
+    }
+
+    private void sendError(DataOutputStream out, int seq, int code, String sqlState, String msg) throws IOException {
+        byte[] msgBytes = msg.getBytes(StandardCharsets.UTF_8);
+        byte[] stateBytes = sqlState.getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        b.write(0xff);
+        writeInt2LE(b, code);
+        b.write('#');
+        b.write(stateBytes, 0, Math.min(5, stateBytes.length));
+        b.write(msgBytes);
+        writePacket(out, seq, b.toByteArray());
+        out.flush();
+    }
+
+    // ── Packet framing ────────────────────────────────────────────────────────
+
+    private static void writePacket(DataOutputStream out, int seq, byte[] payload) throws IOException {
+        int len = payload.length;
+        out.write(len & 0xFF);
+        out.write((len >> 8) & 0xFF);
+        out.write((len >> 16) & 0xFF);
+        out.write(seq & 0xFF);
+        out.write(payload);
+    }
+
+    /** Reads one MySQL packet, returns the payload bytes. */
+    private static byte[] readPacket(DataInputStream in) throws IOException {
+        int b0 = in.read();
+        if (b0 < 0) throw new EOFException();
+        int b1 = in.read();
+        int b2 = in.read();
+        /* seq = */ in.read();
+        int len = b0 | (b1 << 8) | (b2 << 16);
+        if (len == 0) return new byte[0];
+        return in.readNBytes(len);
+    }
+
+    // ── Auth helpers ──────────────────────────────────────────────────────────
+
+    /**
+     * Verifies a mysql_native_password auth token.
+     *
+     * <p>Client sends: SHA1(password) XOR SHA1(challenge + SHA1(SHA1(password))).
+     * We reconstruct the expected token from the stored plaintext password.
+     */
+    static boolean verifyNativePassword(byte[] challenge, byte[] storedPasswordBytes, byte[] token) {
+        if (token == null || token.length == 0) return false;
+        try {
+            MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+            byte[] sha1pwd = sha1.digest(storedPasswordBytes);
+            sha1.reset();
+            byte[] sha1sha1pwd = sha1.digest(sha1pwd);
+
+            sha1.reset();
+            sha1.update(challenge);
+            sha1.update(sha1sha1pwd);
+            byte[] xorMask = sha1.digest();
+
+            byte[] expected = new byte[20];
+            for (int i = 0; i < 20; i++) {
+                expected[i] = (byte) (sha1pwd[i] ^ xorMask[i]);
+            }
+            return Arrays.equals(expected, Arrays.copyOf(token, 20));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // ── Low-level I/O helpers ─────────────────────────────────────────────────
+
+    private static byte[] randomBytes(int len) {
+        byte[] b = new byte[len];
+        ThreadLocalRandom.current().nextBytes(b);
+        // Avoid null bytes in the challenge (mysql_native_password uses null-term semantics)
+        for (int i = 0; i < len; i++) {
+            if (b[i] == 0) b[i] = 1;
+        }
+        return b;
+    }
+
+    private static void writeNullString(OutputStream out, String s) throws IOException {
+        out.write(s.getBytes(StandardCharsets.UTF_8));
+        out.write(0);
+    }
+
+    private static void writeInt2LE(OutputStream out, int v) throws IOException {
+        out.write(v & 0xFF);
+        out.write((v >> 8) & 0xFF);
+    }
+
+    private static void writeInt4LE(OutputStream out, int v) throws IOException {
+        out.write(v & 0xFF);
+        out.write((v >> 8) & 0xFF);
+        out.write((v >> 16) & 0xFF);
+        out.write((v >> 24) & 0xFF);
+    }
+
+    private static int readInt4LE(byte[] b, int offset) {
+        return (b[offset] & 0xFF) |
+               ((b[offset + 1] & 0xFF) << 8) |
+               ((b[offset + 2] & 0xFF) << 16) |
+               ((b[offset + 3] & 0xFF) << 24);
+    }
+
+    private static String readNullString(byte[] b, int offset) {
+        int end = offset;
+        while (end < b.length && b[end] != 0) end++;
+        return new String(b, offset, end - offset, StandardCharsets.UTF_8);
+    }
+
+    private static String nonBlank(String value, String defaultValue) {
+        return (value == null || value.isBlank()) ? defaultValue : value;
+    }
+}

--- a/skadi-sql-gateway/src/main/resources/application.yml
+++ b/skadi-sql-gateway/src/main/resources/application.yml
@@ -59,6 +59,18 @@ skadi:
       ttl: 5m
       max-entries: 500
 
+    mysqlwire:
+      enabled: false
+      host: 0.0.0.0
+      port: 13306
+      auth:
+        mode: trust  # trust | password
+        # credential-store: plaintext
+        # users:
+        #   alice: secret
+      # query-timeout: 5m
+      # max-concurrent-queries-per-user: 10
+
     databricks:
       enabled: false
       host: ""

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlHandshakeTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlHandshakeTest.java
@@ -1,0 +1,175 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.iceforge.skadi.sqlgateway.config.SqlGatewayProperties;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B8 — Verifies the MySQL wire server greeting (Handshake v10) packet.
+ * Uses a raw socket so no MySQL JDBC driver is required in the test classpath.
+ */
+class MySqlHandshakeTest {
+
+    private static SqlGatewayProperties.MySqlWire trustProps() {
+        SqlGatewayProperties.PgWire.Auth auth =
+                new SqlGatewayProperties.PgWire.Auth("trust", null, Map.of(), null);
+        return new SqlGatewayProperties.MySqlWire(true, "127.0.0.1", 0, auth, null, null);
+    }
+
+    @Test
+    void server_sends_handshake_v10() throws Exception {
+        try (MySqlWireServer server = new MySqlWireServer(trustProps(), null)) {
+            server.start();
+            waitForPort(server);
+
+            try (Socket sock = new Socket("127.0.0.1", server.getLocalPort());
+                 DataInputStream in = new DataInputStream(sock.getInputStream())) {
+
+                // Read greeting packet
+                byte[] greeting = readPacket(in);
+
+                // Protocol version must be 10
+                assertThat(greeting[0] & 0xFF).isEqualTo(10);
+
+                // Server version string ends with \0; find it
+                int versionEnd = 1;
+                while (versionEnd < greeting.length && greeting[versionEnd] != 0) versionEnd++;
+                String version = new String(greeting, 1, versionEnd - 1, StandardCharsets.UTF_8);
+                assertThat(version).startsWith("8.0");
+
+                // Auth plugin name appears at the end; find "mysql_native_password"
+                String greetingStr = new String(greeting, StandardCharsets.UTF_8);
+                assertThat(greetingStr).contains("mysql_native_password");
+            }
+        }
+    }
+
+    @Test
+    void server_sends_unique_connection_ids() throws Exception {
+        try (MySqlWireServer server = new MySqlWireServer(trustProps(), null)) {
+            server.start();
+            waitForPort(server);
+
+            int id1 = connectAndReadConnectionId(server.getLocalPort());
+            int id2 = connectAndReadConnectionId(server.getLocalPort());
+            assertThat(id1).isNotEqualTo(id2);
+        }
+    }
+
+    @Test
+    void trust_auth_accepted_with_empty_password() throws Exception {
+        try (MySqlWireServer server = new MySqlWireServer(trustProps(), null)) {
+            server.start();
+            waitForPort(server);
+
+            try (Socket sock = new Socket("127.0.0.1", server.getLocalPort());
+                 DataInputStream in = new DataInputStream(sock.getInputStream());
+                 DataOutputStream out = new DataOutputStream(sock.getOutputStream())) {
+
+                readPacket(in); // greeting
+
+                // Send minimal client handshake response (CLIENT_PROTOCOL_41, username="test", no auth data)
+                sendMinimalHandshake(out, "test", new byte[0]);
+
+                // Should receive OK packet (0x00)
+                byte[] response = readPacket(in);
+                assertThat(response[0] & 0xFF).as("expected OK packet (0x00)").isEqualTo(0);
+            }
+        }
+    }
+
+    @Test
+    void password_auth_rejects_wrong_password() throws Exception {
+        SqlGatewayProperties.PgWire.Auth auth =
+                new SqlGatewayProperties.PgWire.Auth("password", "plaintext",
+                        Map.of("alice", "correct-password"), null);
+        SqlGatewayProperties.MySqlWire props =
+                new SqlGatewayProperties.MySqlWire(true, "127.0.0.1", 0, auth, null, null);
+
+        try (MySqlWireServer server = new MySqlWireServer(props, null)) {
+            server.start();
+            waitForPort(server);
+
+            try (Socket sock = new Socket("127.0.0.1", server.getLocalPort());
+                 DataInputStream in = new DataInputStream(sock.getInputStream());
+                 DataOutputStream out = new DataOutputStream(sock.getOutputStream())) {
+
+                readPacket(in); // greeting
+
+                // Send wrong password (empty token — 20 zero bytes would normally be a real hash)
+                sendMinimalHandshake(out, "alice", new byte[20]);
+
+                // Should receive ERR packet (0xff)
+                byte[] response = readPacket(in);
+                assertThat(response[0] & 0xFF).as("expected ERR packet (0xff)").isEqualTo(0xff);
+            }
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static int connectAndReadConnectionId(int port) throws Exception {
+        try (Socket sock = new Socket("127.0.0.1", port);
+             DataInputStream in = new DataInputStream(sock.getInputStream())) {
+            byte[] greeting = readPacket(in);
+            // Connection ID is at bytes 5..8 (after protocol version + null-terminated version)
+            int versionEnd = 1;
+            while (versionEnd < greeting.length && greeting[versionEnd] != 0) versionEnd++;
+            int offset = versionEnd + 1;
+            return (greeting[offset] & 0xFF)
+                    | ((greeting[offset + 1] & 0xFF) << 8)
+                    | ((greeting[offset + 2] & 0xFF) << 16)
+                    | ((greeting[offset + 3] & 0xFF) << 24);
+        }
+    }
+
+    private static void sendMinimalHandshake(DataOutputStream out, String username, byte[] authResponse)
+            throws Exception {
+        java.io.ByteArrayOutputStream b = new java.io.ByteArrayOutputStream();
+        // Capability flags (4 bytes LE): CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION
+        int caps = 0x00000200 | 0x00008000;
+        b.write(caps & 0xFF); b.write((caps >> 8) & 0xFF); b.write((caps >> 16) & 0xFF); b.write((caps >> 24) & 0xFF);
+        // Max packet size
+        b.write(0xff); b.write(0xff); b.write(0xff); b.write(0x00);
+        // Charset
+        b.write(0x21);
+        // Reserved (23 zeros)
+        b.write(new byte[23]);
+        // Username (null-terminated)
+        b.write(username.getBytes(StandardCharsets.UTF_8));
+        b.write(0);
+        // Auth response length + bytes
+        b.write(authResponse.length & 0xFF);
+        b.write(authResponse);
+
+        byte[] payload = b.toByteArray();
+        // Write packet with seq=1
+        out.write(payload.length & 0xFF);
+        out.write((payload.length >> 8) & 0xFF);
+        out.write((payload.length >> 16) & 0xFF);
+        out.write(1); // seq
+        out.write(payload);
+        out.flush();
+    }
+
+    static byte[] readPacket(DataInputStream in) throws Exception {
+        int b0 = in.read(); if (b0 < 0) throw new java.io.EOFException();
+        int b1 = in.read();
+        int b2 = in.read();
+        in.read(); // seq
+        int len = b0 | (b1 << 8) | (b2 << 16);
+        if (len == 0) return new byte[0];
+        return in.readNBytes(len);
+    }
+
+    private static void waitForPort(MySqlWireServer server) throws Exception {
+        for (int i = 0; i < 50 && server.getLocalPort() == 0; i++) Thread.sleep(10);
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlNativePasswordTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlNativePasswordTest.java
@@ -1,0 +1,77 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B8 — Verifies mysql_native_password challenge-response verification.
+ */
+class MySqlNativePasswordTest {
+
+    /** Computes what a MySQL client sends: SHA1(password) XOR SHA1(challenge + SHA1(SHA1(password))). */
+    private static byte[] clientToken(byte[] challenge, byte[] password) throws Exception {
+        MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+        byte[] sha1pwd = sha1.digest(password);
+        sha1.reset();
+        byte[] sha1sha1pwd = sha1.digest(sha1pwd);
+        sha1.reset();
+        sha1.update(challenge);
+        sha1.update(sha1sha1pwd);
+        byte[] xorMask = sha1.digest();
+        byte[] token = new byte[20];
+        for (int i = 0; i < 20; i++) token[i] = (byte) (sha1pwd[i] ^ xorMask[i]);
+        return token;
+    }
+
+    @Test
+    void correct_password_verifies_successfully() throws Exception {
+        byte[] challenge = new byte[20];
+        for (int i = 0; i < 20; i++) challenge[i] = (byte) (i + 1);
+        byte[] password = "secret".getBytes(StandardCharsets.UTF_8);
+        byte[] token = clientToken(challenge, password);
+        assertThat(MySqlWireSession.verifyNativePassword(challenge, password, token)).isTrue();
+    }
+
+    @Test
+    void wrong_password_fails_verification() throws Exception {
+        byte[] challenge = new byte[20];
+        for (int i = 0; i < 20; i++) challenge[i] = (byte) (i + 1);
+        byte[] correctPassword = "secret".getBytes(StandardCharsets.UTF_8);
+        byte[] wrongPassword = "wrong".getBytes(StandardCharsets.UTF_8);
+        byte[] token = clientToken(challenge, wrongPassword);
+        assertThat(MySqlWireSession.verifyNativePassword(challenge, correctPassword, token)).isFalse();
+    }
+
+    @Test
+    void empty_token_fails_verification() {
+        byte[] challenge = new byte[20];
+        byte[] password = "secret".getBytes(StandardCharsets.UTF_8);
+        assertThat(MySqlWireSession.verifyNativePassword(challenge, password, new byte[0])).isFalse();
+    }
+
+    @Test
+    void null_token_fails_verification() {
+        byte[] challenge = new byte[20];
+        byte[] password = "secret".getBytes(StandardCharsets.UTF_8);
+        assertThat(MySqlWireSession.verifyNativePassword(challenge, password, null)).isFalse();
+    }
+
+    @Test
+    void different_challenges_produce_different_tokens() throws Exception {
+        byte[] challenge1 = new byte[20];
+        byte[] challenge2 = new byte[20];
+        for (int i = 0; i < 20; i++) { challenge1[i] = (byte) (i + 1); challenge2[i] = (byte) (i + 21); }
+        byte[] password = "secret".getBytes(StandardCharsets.UTF_8);
+        byte[] token1 = clientToken(challenge1, password);
+        byte[] token2 = clientToken(challenge2, password);
+        assertThat(token1).isNotEqualTo(token2);
+        assertThat(MySqlWireSession.verifyNativePassword(challenge1, password, token1)).isTrue();
+        assertThat(MySqlWireSession.verifyNativePassword(challenge2, password, token2)).isTrue();
+        // Cross-challenge: wrong
+        assertThat(MySqlWireSession.verifyNativePassword(challenge1, password, token2)).isFalse();
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlQueryRoutingTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlQueryRoutingTest.java
@@ -1,0 +1,218 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.iceforge.skadi.sqlgateway.config.SqlGatewayProperties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B8 — Verifies COM_QUERY routing via raw socket against a MySQL wire server backed by H2.
+ * No MySQL JDBC driver is required — packets are crafted manually.
+ */
+class MySqlQueryRoutingTest {
+
+    private static MySqlWireServer SERVER;
+    private static int PORT;
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        // Wire H2 as the backend executor
+        Class.forName("org.h2.Driver");
+        Connection h2 = DriverManager.getConnection("jdbc:h2:mem:mysql_routing;DB_CLOSE_DELAY=-1", "sa", "");
+        h2.createStatement().execute("CREATE TABLE IF NOT EXISTS items (id INT, name VARCHAR(50))");
+        h2.createStatement().execute("DELETE FROM items");
+        h2.createStatement().execute("INSERT INTO items VALUES (1, 'alpha'), (2, 'beta')");
+
+        MySqlExecutorProviderHolder.set(
+                () -> DriverManager.getConnection("jdbc:h2:mem:mysql_routing", "sa", ""));
+
+        SqlGatewayProperties.PgWire.Auth auth =
+                new SqlGatewayProperties.PgWire.Auth("trust", null, Map.of(), null);
+        SqlGatewayProperties.MySqlWire props =
+                new SqlGatewayProperties.MySqlWire(true, "127.0.0.1", 0, auth, null, null);
+
+        SERVER = new MySqlWireServer(props, null);
+        SERVER.start();
+        for (int i = 0; i < 50 && SERVER.getLocalPort() == 0; i++) Thread.sleep(10);
+        PORT = SERVER.getLocalPort();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (SERVER != null) SERVER.close();
+        MySqlExecutorProviderHolder.set(null);
+    }
+
+    @Test
+    void com_query_select_one_returns_result_set() throws Exception {
+        try (MysqlClient c = connect()) {
+            byte[][] packets = c.query("SELECT 1");
+            // First response packet after column-count should have column defs + rows + EOF
+            // The column count packet contains a single length-encoded integer (1)
+            assertThat(packets[0][0] & 0xFF).isEqualTo(1); // column count = 1
+        }
+    }
+
+    @Test
+    void com_query_returns_multiple_rows() throws Exception {
+        try (MysqlClient c = connect()) {
+            // Column count + 2 col-defs + EOF + 2 rows + EOF = 7 packets
+            byte[][] packets = c.query("SELECT id, name FROM items ORDER BY id");
+            // packet[0] = column count (2 columns)
+            assertThat(packets[0][0] & 0xFF).isEqualTo(2);
+            // Total packet count: 1 (colcnt) + 2 (coldefs) + 1 (EOF) + 2 (rows) + 1 (EOF) = 7
+            assertThat(packets.length).isEqualTo(7);
+        }
+    }
+
+    @Test
+    void com_query_row_values_encoded_as_length_prefixed_strings() throws Exception {
+        try (MysqlClient c = connect()) {
+            byte[][] packets = c.query("SELECT id, name FROM items ORDER BY id");
+            // First data row is packet index 4 (0=colcnt, 1=coldef, 2=coldef, 3=EOF, 4=row1)
+            byte[] row1 = packets[4];
+            // First column "1": length=1, data="1"
+            assertThat(row1[0] & 0xFF).isEqualTo(1);  // length prefix
+            assertThat((char) row1[1]).isEqualTo('1'); // value
+        }
+    }
+
+    @Test
+    void com_ping_returns_ok() throws Exception {
+        try (MysqlClient c = connect()) {
+            byte[] resp = c.ping();
+            assertThat(resp[0] & 0xFF).isEqualTo(0x00); // OK
+        }
+    }
+
+    @Test
+    void information_schema_tables_served_from_metadata_facade() throws Exception {
+        try (MysqlClient c = connect()) {
+            byte[][] packets = c.query("SELECT table_name FROM information_schema.tables");
+            // Should not error (0xff first byte)
+            assertThat(packets[0][0] & 0xFF).isNotEqualTo(0xff);
+        }
+    }
+
+    @Test
+    void unsupported_command_returns_error() throws Exception {
+        try (MysqlClient c = connect()) {
+            // COM_STATISTICS (0x09) — not implemented
+            byte[] resp = c.sendRawCommand(new byte[] { 0x09 });
+            assertThat(resp[0] & 0xFF).isEqualTo(0xff); // ERR packet
+        }
+    }
+
+    // ── Minimal MySQL client ──────────────────────────────────────────────────
+
+    static class MysqlClient implements AutoCloseable {
+        final Socket socket;
+        final DataInputStream in;
+        final DataOutputStream out;
+
+        MysqlClient(int port) throws Exception {
+            socket = new Socket("127.0.0.1", port);
+            in = new DataInputStream(socket.getInputStream());
+            out = new DataOutputStream(socket.getOutputStream());
+
+            // Read greeting
+            readPacket(); // greeting
+
+            // Send trust handshake
+            sendHandshake("test");
+
+            // Read OK
+            readPacket();
+        }
+
+        /** Sends COM_QUERY and collects all response packets until the final EOF. */
+        byte[][] query(String sql) throws Exception {
+            byte[] sqlBytes = sql.getBytes(StandardCharsets.UTF_8);
+            byte[] payload = new byte[1 + sqlBytes.length];
+            payload[0] = 0x03; // COM_QUERY
+            System.arraycopy(sqlBytes, 0, payload, 1, sqlBytes.length);
+            writePacket(0, payload);
+
+            // Collect packets: colcnt + coldefs + EOF + rows + EOF
+            byte[] colCountPkt = readPacket();
+            int colCount = colCountPkt[0] & 0xFF;
+
+            java.util.List<byte[]> packets = new java.util.ArrayList<>();
+            packets.add(colCountPkt);
+
+            // Check for immediate error
+            if (colCount == 0xff) return packets.toArray(new byte[0][]);
+            // Check for OK (no result set)
+            if (colCount == 0x00) return packets.toArray(new byte[0][]);
+
+            // Read colCount column definition packets
+            for (int i = 0; i < colCount; i++) packets.add(readPacket());
+            // EOF after defs
+            packets.add(readPacket());
+            // Rows until EOF
+            while (true) {
+                byte[] pkt = readPacket();
+                packets.add(pkt);
+                if ((pkt[0] & 0xFF) == 0xfe && pkt.length < 9) break; // EOF
+            }
+            return packets.toArray(new byte[0][]);
+        }
+
+        byte[] ping() throws Exception {
+            writePacket(0, new byte[] { 0x0e });
+            return readPacket();
+        }
+
+        byte[] sendRawCommand(byte[] payload) throws Exception {
+            writePacket(0, payload);
+            return readPacket();
+        }
+
+        private void sendHandshake(String username) throws Exception {
+            ByteArrayOutputStream b = new ByteArrayOutputStream();
+            int caps = 0x00000200 | 0x00008000; // PROTOCOL_41 | SECURE_CONNECTION
+            b.write(caps & 0xFF); b.write((caps >> 8) & 0xFF);
+            b.write((caps >> 16) & 0xFF); b.write((caps >> 24) & 0xFF);
+            b.write(new byte[4]); // max packet size
+            b.write(0x21);        // charset
+            b.write(new byte[23]); // reserved
+            b.write(username.getBytes(StandardCharsets.UTF_8)); b.write(0);
+            b.write(0); // auth response length = 0 (trust)
+            writePacket(1, b.toByteArray());
+        }
+
+        private void writePacket(int seq, byte[] payload) throws Exception {
+            out.write(payload.length & 0xFF);
+            out.write((payload.length >> 8) & 0xFF);
+            out.write((payload.length >> 16) & 0xFF);
+            out.write(seq & 0xFF);
+            out.write(payload);
+            out.flush();
+        }
+
+        private byte[] readPacket() throws Exception {
+            int b0 = in.read(); if (b0 < 0) throw new java.io.EOFException();
+            int b1 = in.read(); int b2 = in.read();
+            in.read(); // seq
+            int len = b0 | (b1 << 8) | (b2 << 16);
+            if (len == 0) return new byte[0];
+            return in.readNBytes(len);
+        }
+
+        @Override
+        public void close() throws Exception { socket.close(); }
+    }
+
+    private static MysqlClient connect() throws Exception { return new MysqlClient(PORT); }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlTypeMapperTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlTypeMapperTest.java
@@ -1,0 +1,98 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B8 — Verifies JDBC → MySQL wire-type mapping.
+ */
+class MySqlTypeMapperTest {
+
+    @Test
+    void bigint_maps_to_longlong() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.BIGINT))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_LONGLONG);
+    }
+
+    @Test
+    void integer_maps_to_long() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.INTEGER))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_LONG);
+    }
+
+    @Test
+    void smallint_maps_to_short() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.SMALLINT))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_SHORT);
+    }
+
+    @Test
+    void double_maps_to_double() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.DOUBLE))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_DOUBLE);
+    }
+
+    @Test
+    void decimal_maps_to_newdecimal() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.DECIMAL))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_NEWDECIMAL);
+    }
+
+    @Test
+    void date_maps_to_date() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.DATE))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_DATE);
+    }
+
+    @Test
+    void timestamp_maps_to_datetime() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.TIMESTAMP))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_DATETIME);
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.TIMESTAMP_WITH_TIMEZONE))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_DATETIME);
+    }
+
+    @Test
+    void varchar_maps_to_var_string() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.VARCHAR))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_VAR_STRING);
+    }
+
+    @Test
+    void clob_maps_to_blob() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.CLOB))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_BLOB);
+    }
+
+    @Test
+    void unknown_type_defaults_to_var_string() {
+        assertThat(JdbcToMySqlTypeMapper.toMySqlType(Types.OTHER))
+                .isEqualTo(JdbcToMySqlTypeMapper.MYSQL_TYPE_VAR_STRING);
+    }
+
+    @Test
+    void numeric_types_have_num_flag() {
+        assertThat(JdbcToMySqlTypeMapper.flagsFor(Types.INTEGER))
+                .isEqualTo(JdbcToMySqlTypeMapper.FLAG_NUM);
+        assertThat(JdbcToMySqlTypeMapper.flagsFor(Types.BIGINT))
+                .isEqualTo(JdbcToMySqlTypeMapper.FLAG_NUM);
+    }
+
+    @Test
+    void string_type_has_no_num_flag() {
+        assertThat(JdbcToMySqlTypeMapper.flagsFor(Types.VARCHAR)).isEqualTo(0);
+    }
+
+    @Test
+    void display_len_falls_back_to_precision() {
+        assertThat(JdbcToMySqlTypeMapper.displayLen(Types.VARCHAR, 100)).isEqualTo(100);
+    }
+
+    @Test
+    void display_len_default_for_bigint_when_no_precision() {
+        assertThat(JdbcToMySqlTypeMapper.displayLen(Types.BIGINT, 0)).isEqualTo(20);
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireHealthIndicatorTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/mysqwire/MySqlWireHealthIndicatorTest.java
@@ -1,0 +1,79 @@
+package org.iceforge.skadi.sqlgateway.mysqwire;
+
+import org.iceforge.skadi.sqlgateway.config.SqlGatewayProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * B8 — Verifies {@link MySqlWireHealthIndicator} lifecycle states.
+ */
+class MySqlWireHealthIndicatorTest {
+
+    @Test
+    void reports_up_when_server_is_running() throws Exception {
+        SqlGatewayProperties.PgWire.Auth auth =
+                new SqlGatewayProperties.PgWire.Auth("trust", null, Map.of(), null);
+        SqlGatewayProperties.MySqlWire props =
+                new SqlGatewayProperties.MySqlWire(true, "127.0.0.1", 0, auth, null, null);
+
+        try (MySqlWireServer server = new MySqlWireServer(props, null)) {
+            server.start();
+            for (int i = 0; i < 50 && server.getLocalPort() == 0; i++) Thread.sleep(10);
+
+            MySqlWireServerLifecycle lifecycle = stubLifecycle(props, server);
+            MySqlWireHealthIndicator indicator = new MySqlWireHealthIndicator(lifecycle);
+
+            Health health = indicator.health();
+
+            assertThat(health.getStatus()).isEqualTo(Status.UP);
+            assertThat(health.getDetails()).containsKey("port");
+            assertThat((Integer) health.getDetails().get("port")).isGreaterThan(0);
+            assertThat(health.getDetails()).containsEntry("protocol", "mysql/MySQL-wire");
+        }
+    }
+
+    @Test
+    void reports_down_when_lifecycle_not_running() {
+        SqlGatewayProperties.PgWire.Auth auth =
+                new SqlGatewayProperties.PgWire.Auth("trust", null, Map.of(), null);
+        SqlGatewayProperties.MySqlWire props =
+                new SqlGatewayProperties.MySqlWire(false, "127.0.0.1", 13306, auth, null, null);
+
+        SqlGatewayProperties gwProps =
+                new SqlGatewayProperties(null, null, null, null, null, null,
+                        new SqlGatewayProperties.MySqlWire(false, "127.0.0.1", 13306, auth, null, null));
+        MySqlWireServerLifecycle lifecycle = new MySqlWireServerLifecycle(gwProps);
+        // Do not start — simulates disabled state
+
+        MySqlWireHealthIndicator indicator = new MySqlWireHealthIndicator(lifecycle);
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsKey("reason");
+    }
+
+    // --- helpers ---
+
+    private static MySqlWireServerLifecycle stubLifecycle(SqlGatewayProperties.MySqlWire props,
+                                                           MySqlWireServer server) {
+        SqlGatewayProperties gwProps =
+                new SqlGatewayProperties(null, null, null, null, null, null, props);
+        MySqlWireServerLifecycle lifecycle = new MySqlWireServerLifecycle(gwProps);
+        try {
+            java.lang.reflect.Field f = MySqlWireServerLifecycle.class.getDeclaredField("server");
+            f.setAccessible(true);
+            f.set(lifecycle, server);
+            java.lang.reflect.Field r = MySqlWireServerLifecycle.class.getDeclaredField("running");
+            r.setAccessible(true);
+            r.set(lifecycle, true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return lifecycle;
+    }
+}

--- a/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/PgWireHealthIndicatorTest.java
+++ b/skadi-sql-gateway/src/test/java/org/iceforge/skadi/sqlgateway/pgwire/PgWireHealthIndicatorTest.java
@@ -50,7 +50,7 @@ class PgWireHealthIndicatorTest {
 
         // Lifecycle that reports not-running (pgwire.enabled=false).
         PgWireServerLifecycle lifecycle = new PgWireServerLifecycle(
-                new SqlGatewayProperties(null, null, props, null, null, null));
+                new SqlGatewayProperties(null, null, props, null, null, null, null));
         // Do not call lifecycle.start() — simulates disabled state.
 
         PgWireHealthIndicator indicator = new PgWireHealthIndicator(lifecycle);
@@ -69,7 +69,7 @@ class PgWireHealthIndicatorTest {
                 new SqlGatewayProperties.PgWire(true, props.host(), props.port(), props.auth(),
                         null, null, null, null, null);
         PgWireServerLifecycle lifecycle = new PgWireServerLifecycle(
-                new SqlGatewayProperties(null, null, enabledProps, null, null, null));
+                new SqlGatewayProperties(null, null, enabledProps, null, null, null, null));
         // Reflectively set the server field so the lifecycle reports the live server.
         try {
             java.lang.reflect.Field f = PgWireServerLifecycle.class.getDeclaredField("server");


### PR DESCRIPTION
New mysqwire package: MySqlWireServer (Handshake v10 TCP server), MySqlWireSession (COM_QUERY text protocol, mysql_native_password auth, metadata facade, trust/password modes), MySqlWireServerLifecycle (SmartLifecycle), MySqlWireHealthIndicator (/actuator/health/mySqlWire), JdbcToMySqlTypeMapper, MySqlExecutorProviderHolder/Wiring.

SqlGatewayProperties gains MySqlWire record (7th field); SqlDialectBridgeOptions gains defaultForMySqlWire() factory. Default port 13306, disabled by default (mysqlwire.enabled=false).

Shares Databricks executor, dialect bridge (MYSQL), and metadata facade with the pgwire endpoint — no duplication of execution core.

31 new tests: MySqlHandshakeTest, MySqlNativePasswordTest, MySqlQueryRoutingTest, MySqlTypeMapperTest, MySqlWireHealthIndicatorTest. Total: 232 tests passing.