### PR TITLE
feat: extend semantic contract explanation metadata model (E1.1)

### DIFF
--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticContract.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticContract.java
@@ -1,5 +1,7 @@
 package org.iceforge.skadi.semantic.contract;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -40,14 +42,16 @@ import java.util.Objects;
  *     new SemanticEntity("mxl_risk", "...",
  *         new SemanticEndpoint("main", "risk", "gold_risk"), List.of()),
  *     List.of(new SemanticMeasure("pnl", "Total PnL", "SUM(pnl)",
- *                                 SemanticFieldType.DECIMAL, "")),
+ *                                 SemanticFieldType.DECIMAL, "", null)),
  *     List.of(new SemanticDimension("book", "book",
  *                                   SemanticFieldType.STRING, "Trading Book",
- *                                   true, true)),
+ *                                   true, true, null)),
  *     SemanticAccessPolicy.unrestricted(),
- *     SemanticCachePolicy.ttl(300L));
+ *     SemanticCachePolicy.ttl(300L),
+ *     null);
  * }</pre>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SemanticContract(
         String name,
         SemanticContractVersion version,
@@ -56,7 +60,8 @@ public record SemanticContract(
         List<SemanticMeasure> measures,
         List<SemanticDimension> dimensions,
         SemanticAccessPolicy accessPolicy,
-        SemanticCachePolicy cachePolicy) {
+        SemanticCachePolicy cachePolicy,
+        SemanticContractExplanation explanation) {
 
     /**
      * @param name         unique contract identifier used in semantic queries
@@ -72,6 +77,8 @@ public record SemanticContract(
      *                     use {@link SemanticAccessPolicy#unrestricted()} for no restrictions
      * @param cachePolicy  declared cache hint; must not be null;
      *                     use {@link SemanticCachePolicy#none()} to opt out of caching
+     * @param explanation  optional business-facing explanation metadata for buddy chat
+     *                     interrogation; may be null
      */
     public SemanticContract {
         Objects.requireNonNull(name, "name must not be null");

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticContractExplanation.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticContractExplanation.java
@@ -1,0 +1,54 @@
+package org.iceforge.skadi.semantic.contract;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * Business-facing explanation metadata for a {@link SemanticContract}.
+ *
+ * <p>Carries governance and documentation fields that allow the buddy chat to
+ * interrogate the contract for human-readable context without maintaining its
+ * own independent business definitions. All fields are optional; a null value
+ * means the information is not specified for this contract version.
+ *
+ * <ul>
+ *   <li>{@link #owner} — team or individual responsible for this contract</li>
+ *   <li>{@link #intendedUsage} — guidance on when and how to use this contract</li>
+ *   <li>{@link #caveats} — known limitations, ambiguities, or gotchas</li>
+ *   <li>{@link #grain} — the row-level granularity of the underlying dataset</li>
+ *   <li>{@link #outputShapes} — names of the typical result shapes this contract produces</li>
+ *   <li>{@link #lineageHook} — placeholder identifying the upstream lineage hook</li>
+ *   <li>{@link #entitlementBehavior} — placeholder describing access entitlement behavior</li>
+ *   <li>{@link #validGroupingPaths} — dimension names or paths that form valid GROUP BY combinations</li>
+ * </ul>
+ *
+ * <pre>{@code
+ * var explanation = new SemanticContractExplanation(
+ *     "Risk Analytics",
+ *     "Use for daily PnL and Greeks reporting at book level.",
+ *     List.of("Data is only available after 7 AM UTC"),
+ *     "One row per book per close-of-business date",
+ *     List.of("pnl_by_book", "greeks_by_desk"),
+ *     new SemanticLineageHook("RISK-LIN-01", "BCBS 239 lineage"),
+ *     new SemanticEntitlementBehavior("ROW_FILTER", "Filtered by book entitlement"),
+ *     List.of("cob_date", "book", "cob_date,book"));
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SemanticContractExplanation(
+        String owner,
+        String intendedUsage,
+        List<String> caveats,
+        String grain,
+        List<String> outputShapes,
+        SemanticLineageHook lineageHook,
+        SemanticEntitlementBehavior entitlementBehavior,
+        List<String> validGroupingPaths) {
+
+    public SemanticContractExplanation {
+        caveats           = caveats           == null ? null : List.copyOf(caveats);
+        outputShapes      = outputShapes      == null ? null : List.copyOf(outputShapes);
+        validGroupingPaths = validGroupingPaths == null ? null : List.copyOf(validGroupingPaths);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticDimension.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticDimension.java
@@ -1,5 +1,7 @@
 package org.iceforge.skadi.semantic.contract;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.Objects;
 
 /**
@@ -16,24 +18,27 @@ import java.util.Objects;
  * <pre>{@code
  * var book = new SemanticDimension(
  *     "book", "book", SemanticFieldType.STRING,
- *     "Trading Book", true, true);
+ *     "Trading Book", true, true, null);
  * }</pre>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SemanticDimension(
         String name,
         String column,
         SemanticFieldType type,
         String label,
         boolean filterable,
-        boolean groupable) {
+        boolean groupable,
+        SemanticDimensionExplanation explanation) {
 
     /**
-     * @param name       unique dimension identifier within the contract; must not be null or blank
-     * @param column     physical column name in the backing table; must not be null or blank
-     * @param type       data type of the column; must not be null
-     * @param label      display label for UI and reports; must not be null
-     * @param filterable whether callers may use this dimension as a filter
-     * @param groupable  whether callers may group by this dimension
+     * @param name        unique dimension identifier within the contract; must not be null or blank
+     * @param column      physical column name in the backing table; must not be null or blank
+     * @param type        data type of the column; must not be null
+     * @param label       display label for UI and reports; must not be null
+     * @param filterable  whether callers may use this dimension as a filter
+     * @param groupable   whether callers may group by this dimension
+     * @param explanation optional business-facing explanation metadata; may be null
      */
     public SemanticDimension {
         Objects.requireNonNull(name, "name must not be null");

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticDimensionExplanation.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticDimensionExplanation.java
@@ -1,0 +1,27 @@
+package org.iceforge.skadi.semantic.contract;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * Business-facing explanation metadata for a {@link SemanticDimension}.
+ *
+ * <p>Captures a description and known caveats that help the buddy chat
+ * contextualize a dimension for end users. All fields are optional.
+ *
+ * <pre>{@code
+ * var explanation = new SemanticDimensionExplanation(
+ *     "The legal entity book code as per the risk system.",
+ *     List.of("Book codes change during reorg periods"));
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SemanticDimensionExplanation(
+        String description,
+        List<String> caveats) {
+
+    public SemanticDimensionExplanation {
+        caveats = caveats == null ? null : List.copyOf(caveats);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticEntitlementBehavior.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticEntitlementBehavior.java
@@ -1,0 +1,18 @@
+package org.iceforge.skadi.semantic.contract;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Placeholder value object for entitlement behavior metadata within a
+ * {@link SemanticContractExplanation}.
+ *
+ * <p>Describes how access entitlements are applied to this contract.
+ * All fields are optional; a null value means the information is not specified.
+ *
+ * <p>This type is a representation-only placeholder. Entitlement enforcement is out of scope.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SemanticEntitlementBehavior(
+        String mode,
+        String description) {
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticLineageHook.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticLineageHook.java
@@ -1,0 +1,17 @@
+package org.iceforge.skadi.semantic.contract;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Placeholder value object for lineage hook metadata within a {@link SemanticContractExplanation}.
+ *
+ * <p>Identifies an upstream lineage hook by ID and provides a human-readable description.
+ * All fields are optional; a null value means the information is not specified.
+ *
+ * <p>This type is a representation-only placeholder. Lineage hook enforcement is out of scope.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SemanticLineageHook(
+        String hookId,
+        String description) {
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticMeasure.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticMeasure.java
@@ -1,5 +1,7 @@
 package org.iceforge.skadi.semantic.contract;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.Objects;
 
 /**
@@ -18,15 +20,17 @@ import java.util.Objects;
  * <pre>{@code
  * var pnl = new SemanticMeasure(
  *     "pnl", "Total PnL", "SUM(pnl)", SemanticFieldType.DECIMAL,
- *     "Sum of daily profit and loss");
+ *     "Sum of daily profit and loss", null);
  * }</pre>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SemanticMeasure(
         String name,
         String label,
         String expression,
         SemanticFieldType type,
-        String description) {
+        String description,
+        SemanticMeasureExplanation explanation) {
 
     /**
      * @param name        unique measure identifier within the contract; must not be null or blank
@@ -34,6 +38,7 @@ public record SemanticMeasure(
      * @param expression  SQL aggregation fragment, e.g. {@code "SUM(pnl)"}; must not be null or blank
      * @param type        result data type; must not be null
      * @param description human-readable description; may be empty but not null
+     * @param explanation optional business-facing explanation metadata; may be null
      */
     public SemanticMeasure {
         Objects.requireNonNull(name, "name must not be null");

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticMeasureExplanation.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/contract/SemanticMeasureExplanation.java
@@ -1,0 +1,27 @@
+package org.iceforge.skadi.semantic.contract;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * Business-facing explanation metadata for a {@link SemanticMeasure}.
+ *
+ * <p>Captures intended usage guidance and known caveats that help the buddy chat
+ * contextualize a measure for end users. All fields are optional.
+ *
+ * <pre>{@code
+ * var explanation = new SemanticMeasureExplanation(
+ *     "Use for daily PnL reporting; do not compare across desks without normalization.",
+ *     List.of("Includes unrealized positions", "FX rates are end-of-day"));
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SemanticMeasureExplanation(
+        String intendedUsage,
+        List<String> caveats) {
+
+    public SemanticMeasureExplanation {
+        caveats = caveats == null ? null : List.copyOf(caveats);
+    }
+}

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/ContractCompositionTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/ContractCompositionTest.java
@@ -73,13 +73,13 @@ class ContractCompositionTest {
                 "mxl_risk", "MXL risk gold layer",
                 new SemanticEndpoint("main", "risk", "gold_risk"),
                 List.of(new SemanticRuleRef("BCBS239-01", "lineage requirement")));
-        var pnl  = new SemanticMeasure("pnl", "Total PnL", "SUM(pnl)", SemanticFieldType.DECIMAL, "");
-        var book = new SemanticDimension("book", "book", SemanticFieldType.STRING, "Book", true, true);
+        var pnl  = new SemanticMeasure("pnl", "Total PnL", "SUM(pnl)", SemanticFieldType.DECIMAL, "", null);
+        var book = new SemanticDimension("book", "book", SemanticFieldType.STRING, "Book", true, true, null);
         return new SemanticContract(
                 "mxl_risk", new SemanticContractVersion("1.0.0"),
                 "MXL risk gold layer",
                 entity, List.of(pnl), List.of(book),
-                SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.ttl(300L));
+                SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.ttl(300L), null);
     }
 
     static SemanticQueryContract buildQueryContract() {
@@ -258,11 +258,11 @@ class ContractCompositionTest {
     @Test
     void defense_mutableListToSemanticContract_doesNotAffectMeasures() {
         var mutable = new ArrayList<SemanticMeasure>();
-        mutable.add(new SemanticMeasure("pnl", "PnL", "SUM(pnl)", SemanticFieldType.DECIMAL, ""));
+        mutable.add(new SemanticMeasure("pnl", "PnL", "SUM(pnl)", SemanticFieldType.DECIMAL, "", null));
         var entity   = new SemanticEntity("c", "", new SemanticEndpoint("a", "b", "c"), List.of());
         var contract = new SemanticContract("c", new SemanticContractVersion("1.0.0"), "", entity,
-                mutable, List.of(), SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none());
-        mutable.add(new SemanticMeasure("delta", "Delta", "SUM(delta)", SemanticFieldType.DECIMAL, ""));
+                mutable, List.of(), SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), null);
+        mutable.add(new SemanticMeasure("delta", "Delta", "SUM(delta)", SemanticFieldType.DECIMAL, "", null));
         assertEquals(1, contract.measures().size(),
                 "SemanticContract.measures must be defensively copied");
     }
@@ -299,7 +299,7 @@ class ContractCompositionTest {
         // registering a second contract does not affect the earlier snapshot
         var c2 = new SemanticContract("other", new SemanticContractVersion("1.0.0"), "",
                 new SemanticEntity("other", "", new SemanticEndpoint("a", "b", "c"), List.of()),
-                List.of(), List.of(), SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none());
+                List.of(), List.of(), SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), null);
         registry.register(c2);
         assertEquals(1, snapshot.size(), "earlier snapshot must not grow after registration");
         assertEquals(2, registry.list().size());

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/contract/SemanticContractJsonTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/contract/SemanticContractJsonTest.java
@@ -45,17 +45,17 @@ class SemanticContractJsonTest {
 
         var measures = List.of(
                 new SemanticMeasure("pnl", "Total PnL", "SUM(pnl)",
-                        SemanticFieldType.DECIMAL, "Sum of daily profit and loss"),
+                        SemanticFieldType.DECIMAL, "Sum of daily profit and loss", null),
                 new SemanticMeasure("delta_risk", "Delta Risk", "SUM(delta)",
-                        SemanticFieldType.DECIMAL, "Sum of delta sensitivities"));
+                        SemanticFieldType.DECIMAL, "Sum of delta sensitivities", null));
 
         var dimensions = List.of(
                 new SemanticDimension("cob_date", "cob_date", SemanticFieldType.DATE,
-                        "Close of Business Date", true, true),
+                        "Close of Business Date", true, true, null),
                 new SemanticDimension("book", "book", SemanticFieldType.STRING,
-                        "Trading Book", true, true),
+                        "Trading Book", true, true, null),
                 new SemanticDimension("desk", "desk", SemanticFieldType.STRING,
-                        "Trading Desk", true, false));
+                        "Trading Desk", true, false, null));
 
         var access = new SemanticAccessPolicy(
                 List.of(new SemanticRoleRef("risk_analyst"), new SemanticRoleRef("risk_viewer")),
@@ -69,7 +69,7 @@ class SemanticContractJsonTest {
                 "mxl_risk",
                 new SemanticContractVersion("1.0.0"),
                 "MXL risk gold layer — daily PnL and Greeks",
-                entity, measures, dimensions, access, cache);
+                entity, measures, dimensions, access, cache, null);
     }
 
     // ── SemanticContract round-trip ───────────────────────────────────────────
@@ -147,7 +147,7 @@ class SemanticContractJsonTest {
     @Test
     void roundTrip_SemanticMeasure() throws Exception {
         var m  = new SemanticMeasure("pnl", "Total PnL", "SUM(pnl)",
-                SemanticFieldType.DECIMAL, "desc");
+                SemanticFieldType.DECIMAL, "desc", null);
         var m2 = mapper.readValue(mapper.writeValueAsString(m), SemanticMeasure.class);
         assertEquals(m, m2);
         assertEquals(SemanticFieldType.DECIMAL, m2.type());
@@ -156,7 +156,7 @@ class SemanticContractJsonTest {
     @Test
     void roundTrip_SemanticDimension_filterableAndGroupable() throws Exception {
         var d  = new SemanticDimension("book", "book", SemanticFieldType.STRING,
-                "Trading Book", true, false);
+                "Trading Book", true, false, null);
         var d2 = mapper.readValue(mapper.writeValueAsString(d), SemanticDimension.class);
         assertEquals(d, d2);
         assertTrue(d2.filterable());
@@ -166,7 +166,7 @@ class SemanticContractJsonTest {
     @Test
     void roundTrip_allSemanticFieldTypes() throws Exception {
         for (var type : SemanticFieldType.values()) {
-            var m  = new SemanticMeasure("m", "l", "EXPR", type, "");
+            var m  = new SemanticMeasure("m", "l", "EXPR", type, "", null);
             var m2 = mapper.readValue(mapper.writeValueAsString(m), SemanticMeasure.class);
             assertEquals(type, m2.type());
         }
@@ -325,7 +325,7 @@ class SemanticContractJsonTest {
                 mapper.writeValueAsString(contract), SemanticContract.class);
         assertThrows(UnsupportedOperationException.class,
                 () -> restored.measures().add(
-                        new SemanticMeasure("x", "x", "EXPR", SemanticFieldType.INTEGER, "")));
+                        new SemanticMeasure("x", "x", "EXPR", SemanticFieldType.INTEGER, "", null)));
     }
 
     @Test

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/contract/SemanticContractTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/contract/SemanticContractTest.java
@@ -25,11 +25,11 @@ class SemanticContractTest {
     }
 
     static SemanticMeasure pnlMeasure() {
-        return new SemanticMeasure("pnl", "Total PnL", "SUM(pnl)", SemanticFieldType.DECIMAL, "");
+        return new SemanticMeasure("pnl", "Total PnL", "SUM(pnl)", SemanticFieldType.DECIMAL, "", null);
     }
 
     static SemanticDimension bookDim() {
-        return new SemanticDimension("book", "book", SemanticFieldType.STRING, "Trading Book", true, true);
+        return new SemanticDimension("book", "book", SemanticFieldType.STRING, "Trading Book", true, true, null);
     }
 
     static SemanticContract contract() {
@@ -41,7 +41,8 @@ class SemanticContractTest {
                 List.of(pnlMeasure()),
                 List.of(bookDim()),
                 SemanticAccessPolicy.unrestricted(),
-                SemanticCachePolicy.ttl(300L));
+                SemanticCachePolicy.ttl(300L),
+                null);
     }
 
     // ── SemanticContractVersion ───────────────────────────────────────────────
@@ -118,13 +119,13 @@ class SemanticContractTest {
     @Test
     void measure_rejectsBlankExpression() {
         assertThrows(IllegalArgumentException.class,
-                () -> new SemanticMeasure("pnl", "PnL", "", SemanticFieldType.DECIMAL, ""));
+                () -> new SemanticMeasure("pnl", "PnL", "", SemanticFieldType.DECIMAL, "", null));
     }
 
     @Test
     void measure_rejectsNullType() {
         assertThrows(NullPointerException.class,
-                () -> new SemanticMeasure("pnl", "PnL", "SUM(pnl)", null, ""));
+                () -> new SemanticMeasure("pnl", "PnL", "SUM(pnl)", null, "", null));
     }
 
     // ── SemanticDimension ─────────────────────────────────────────────────────
@@ -141,7 +142,7 @@ class SemanticContractTest {
 
     @Test
     void dimension_nonFilterableNonGroupable() {
-        var d = new SemanticDimension("id", "id", SemanticFieldType.LONG, "ID", false, false);
+        var d = new SemanticDimension("id", "id", SemanticFieldType.LONG, "ID", false, false, null);
         assertFalse(d.filterable());
         assertFalse(d.groupable());
     }
@@ -190,7 +191,7 @@ class SemanticContractTest {
         var c = new SemanticContract(
                 "c", new SemanticContractVersion("1.0.0"), "",
                 entity(), mutable, List.of(),
-                SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none());
+                SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), null);
         mutable.add(pnlMeasure());           // mutate original
         assertEquals(1, c.measures().size()); // contract unaffected
     }
@@ -208,7 +209,7 @@ class SemanticContractTest {
                 () -> new SemanticContract(
                         " ", new SemanticContractVersion("1.0.0"), "",
                         entity(), List.of(), List.of(),
-                        SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none()));
+                        SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), null));
     }
 
     @Test
@@ -216,7 +217,7 @@ class SemanticContractTest {
         assertThrows(NullPointerException.class,
                 () -> new SemanticContract(
                         "c", null, "", entity(), List.of(), List.of(),
-                        SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none()));
+                        SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), null));
     }
 
     @Test
@@ -232,7 +233,7 @@ class SemanticContractTest {
         assertThrows(NullPointerException.class,
                 () -> new SemanticContract(
                         "c", new SemanticContractVersion("1.0.0"), "", entity(),
-                        List.of(), List.of(), null, SemanticCachePolicy.none()));
+                        List.of(), List.of(), null, SemanticCachePolicy.none(), null));
     }
 
     @Test
@@ -240,6 +241,6 @@ class SemanticContractTest {
         assertThrows(NullPointerException.class,
                 () -> new SemanticContract(
                         "c", new SemanticContractVersion("1.0.0"), "", entity(),
-                        List.of(), List.of(), SemanticAccessPolicy.unrestricted(), null));
+                        List.of(), List.of(), SemanticAccessPolicy.unrestricted(), null, null));
     }
 }

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/contract/SemanticExplanationMetadataTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/contract/SemanticExplanationMetadataTest.java
@@ -1,0 +1,369 @@
+package org.iceforge.skadi.semantic.contract;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the E1.1 explanation metadata model types.
+ *
+ * <p>Covers construction, field access, defensive copying, JSON round-trips,
+ * and backward compatibility with existing contracts that carry no explanation.
+ * No Spring context, no external services.
+ */
+class SemanticExplanationMetadataTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper()
+                .disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+    }
+
+    // ── SemanticMeasureExplanation ─────────────────────────────────────────────
+
+    @Test
+    void measureExplanation_holdsFields() {
+        var exp = new SemanticMeasureExplanation(
+                "Use for daily PnL reporting.",
+                List.of("Includes unrealized positions", "FX rates are end-of-day"));
+        assertEquals("Use for daily PnL reporting.", exp.intendedUsage());
+        assertEquals(2, exp.caveats().size());
+        assertEquals("Includes unrealized positions", exp.caveats().get(0));
+    }
+
+    @Test
+    void measureExplanation_nullFieldsAllowed() {
+        var exp = new SemanticMeasureExplanation(null, null);
+        assertNull(exp.intendedUsage());
+        assertNull(exp.caveats());
+    }
+
+    @Test
+    void measureExplanation_caveats_defensivelyCopied() {
+        var mutable = new ArrayList<>(List.of("caveat1"));
+        var exp = new SemanticMeasureExplanation("usage", mutable);
+        mutable.add("caveat2");
+        assertEquals(1, exp.caveats().size());
+    }
+
+    @Test
+    void measureExplanation_caveats_listIsUnmodifiable() {
+        var exp = new SemanticMeasureExplanation("usage", List.of("c1"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> exp.caveats().add("extra"));
+    }
+
+    @Test
+    void measureExplanation_roundTrip_withExplanation() throws Exception {
+        var exp = new SemanticMeasureExplanation(
+                "Daily PnL reporting.",
+                List.of("Unrealized positions included"));
+        var restored = mapper.readValue(mapper.writeValueAsString(exp),
+                SemanticMeasureExplanation.class);
+        assertEquals(exp.intendedUsage(), restored.intendedUsage());
+        assertEquals(exp.caveats(), restored.caveats());
+    }
+
+    @Test
+    void measureExplanation_roundTrip_nullFieldsOmittedFromJson() throws Exception {
+        var exp = new SemanticMeasureExplanation(null, null);
+        var json = mapper.writeValueAsString(exp);
+        assertFalse(json.contains("intendedUsage"), "null field should be omitted");
+        assertFalse(json.contains("caveats"), "null field should be omitted");
+    }
+
+    // ── SemanticDimensionExplanation ───────────────────────────────────────────
+
+    @Test
+    void dimensionExplanation_holdsFields() {
+        var exp = new SemanticDimensionExplanation(
+                "Legal entity book code from the risk system.",
+                List.of("Changes during reorg periods"));
+        assertEquals("Legal entity book code from the risk system.", exp.description());
+        assertEquals(1, exp.caveats().size());
+    }
+
+    @Test
+    void dimensionExplanation_nullFieldsAllowed() {
+        var exp = new SemanticDimensionExplanation(null, null);
+        assertNull(exp.description());
+        assertNull(exp.caveats());
+    }
+
+    @Test
+    void dimensionExplanation_caveats_defensivelyCopied() {
+        var mutable = new ArrayList<>(List.of("c1"));
+        var exp = new SemanticDimensionExplanation("desc", mutable);
+        mutable.add("c2");
+        assertEquals(1, exp.caveats().size());
+    }
+
+    @Test
+    void dimensionExplanation_roundTrip() throws Exception {
+        var exp = new SemanticDimensionExplanation(
+                "Trading desk identifier.", List.of("Null for legacy books"));
+        var restored = mapper.readValue(mapper.writeValueAsString(exp),
+                SemanticDimensionExplanation.class);
+        assertEquals(exp.description(), restored.description());
+        assertEquals(exp.caveats(), restored.caveats());
+    }
+
+    @Test
+    void dimensionExplanation_roundTrip_nullFieldsOmittedFromJson() throws Exception {
+        var exp = new SemanticDimensionExplanation(null, null);
+        var json = mapper.writeValueAsString(exp);
+        assertFalse(json.contains("description"), "null field should be omitted");
+        assertFalse(json.contains("caveats"), "null field should be omitted");
+    }
+
+    // ── SemanticLineageHook ────────────────────────────────────────────────────
+
+    @Test
+    void lineageHook_holdsFields() {
+        var hook = new SemanticLineageHook("RISK-LIN-01", "BCBS 239 lineage hook");
+        assertEquals("RISK-LIN-01", hook.hookId());
+        assertEquals("BCBS 239 lineage hook", hook.description());
+    }
+
+    @Test
+    void lineageHook_nullFieldsAllowed() {
+        var hook = new SemanticLineageHook(null, null);
+        assertNull(hook.hookId());
+        assertNull(hook.description());
+    }
+
+    @Test
+    void lineageHook_roundTrip() throws Exception {
+        var hook = new SemanticLineageHook("H-001", "desc");
+        var restored = mapper.readValue(mapper.writeValueAsString(hook),
+                SemanticLineageHook.class);
+        assertEquals(hook.hookId(), restored.hookId());
+        assertEquals(hook.description(), restored.description());
+    }
+
+    @Test
+    void lineageHook_roundTrip_nullFieldsOmittedFromJson() throws Exception {
+        var hook = new SemanticLineageHook(null, null);
+        var json = mapper.writeValueAsString(hook);
+        assertFalse(json.contains("hookId"), "null field should be omitted");
+        assertFalse(json.contains("description"), "null field should be omitted");
+    }
+
+    // ── SemanticEntitlementBehavior ────────────────────────────────────────────
+
+    @Test
+    void entitlementBehavior_holdsFields() {
+        var eb = new SemanticEntitlementBehavior("ROW_FILTER", "Filtered by book entitlement");
+        assertEquals("ROW_FILTER", eb.mode());
+        assertEquals("Filtered by book entitlement", eb.description());
+    }
+
+    @Test
+    void entitlementBehavior_nullFieldsAllowed() {
+        var eb = new SemanticEntitlementBehavior(null, null);
+        assertNull(eb.mode());
+        assertNull(eb.description());
+    }
+
+    @Test
+    void entitlementBehavior_roundTrip() throws Exception {
+        var eb = new SemanticEntitlementBehavior("COLUMN_MASK", "PII columns masked");
+        var restored = mapper.readValue(mapper.writeValueAsString(eb),
+                SemanticEntitlementBehavior.class);
+        assertEquals(eb.mode(), restored.mode());
+        assertEquals(eb.description(), restored.description());
+    }
+
+    // ── SemanticContractExplanation ────────────────────────────────────────────
+
+    @Test
+    void contractExplanation_holdsAllFields() {
+        var hook = new SemanticLineageHook("H-01", "lineage");
+        var eb   = new SemanticEntitlementBehavior("ROW_FILTER", "filtered");
+        var exp  = new SemanticContractExplanation(
+                "Risk Analytics",
+                "Use for daily PnL reporting.",
+                List.of("Data available after 7 AM UTC"),
+                "One row per book per COB date",
+                List.of("pnl_by_book"),
+                hook, eb,
+                List.of("cob_date", "book"));
+
+        assertEquals("Risk Analytics", exp.owner());
+        assertEquals("Use for daily PnL reporting.", exp.intendedUsage());
+        assertEquals(1, exp.caveats().size());
+        assertEquals("One row per book per COB date", exp.grain());
+        assertEquals(1, exp.outputShapes().size());
+        assertSame(hook, exp.lineageHook());
+        assertSame(eb, exp.entitlementBehavior());
+        assertEquals(List.of("cob_date", "book"), exp.validGroupingPaths());
+    }
+
+    @Test
+    void contractExplanation_allNullFieldsAllowed() {
+        var exp = new SemanticContractExplanation(null, null, null, null, null, null, null, null);
+        assertNull(exp.owner());
+        assertNull(exp.intendedUsage());
+        assertNull(exp.caveats());
+        assertNull(exp.grain());
+        assertNull(exp.outputShapes());
+        assertNull(exp.lineageHook());
+        assertNull(exp.entitlementBehavior());
+        assertNull(exp.validGroupingPaths());
+    }
+
+    @Test
+    void contractExplanation_lists_defensivelyCopied() {
+        var mutableCaveats  = new ArrayList<>(List.of("c1"));
+        var mutableShapes   = new ArrayList<>(List.of("s1"));
+        var mutablePaths    = new ArrayList<>(List.of("p1"));
+        var exp = new SemanticContractExplanation(
+                null, null, mutableCaveats, null, mutableShapes, null, null, mutablePaths);
+
+        mutableCaveats.add("c2");
+        mutableShapes.add("s2");
+        mutablePaths.add("p2");
+
+        assertEquals(1, exp.caveats().size());
+        assertEquals(1, exp.outputShapes().size());
+        assertEquals(1, exp.validGroupingPaths().size());
+    }
+
+    @Test
+    void contractExplanation_lists_unmodifiable() {
+        var exp = new SemanticContractExplanation(
+                null, null, List.of("c1"), null, List.of("s1"), null, null, List.of("p1"));
+        assertThrows(UnsupportedOperationException.class, () -> exp.caveats().add("extra"));
+        assertThrows(UnsupportedOperationException.class, () -> exp.outputShapes().add("extra"));
+        assertThrows(UnsupportedOperationException.class, () -> exp.validGroupingPaths().add("extra"));
+    }
+
+    @Test
+    void contractExplanation_roundTrip_full() throws Exception {
+        var exp = new SemanticContractExplanation(
+                "Risk Analytics",
+                "Use for daily PnL reporting.",
+                List.of("Data available after 7 AM UTC"),
+                "One row per book per COB date",
+                List.of("pnl_by_book"),
+                new SemanticLineageHook("H-01", "lineage"),
+                new SemanticEntitlementBehavior("ROW_FILTER", "filtered"),
+                List.of("cob_date", "book"));
+
+        var restored = mapper.readValue(mapper.writeValueAsString(exp),
+                SemanticContractExplanation.class);
+
+        assertEquals(exp.owner(), restored.owner());
+        assertEquals(exp.intendedUsage(), restored.intendedUsage());
+        assertEquals(exp.caveats(), restored.caveats());
+        assertEquals(exp.grain(), restored.grain());
+        assertEquals(exp.outputShapes(), restored.outputShapes());
+        assertEquals(exp.lineageHook(), restored.lineageHook());
+        assertEquals(exp.entitlementBehavior(), restored.entitlementBehavior());
+        assertEquals(exp.validGroupingPaths(), restored.validGroupingPaths());
+    }
+
+    @Test
+    void contractExplanation_roundTrip_nullFieldsOmittedFromJson() throws Exception {
+        var exp = new SemanticContractExplanation(null, null, null, null, null, null, null, null);
+        var json = mapper.writeValueAsString(exp);
+        assertEquals("{}", json, "all-null explanation should serialize to empty object");
+    }
+
+    // ── SemanticContract backward compatibility ────────────────────────────────
+
+    @Test
+    void contract_nullExplanation_isAllowed() {
+        var entity = new SemanticEntity("c", "", new SemanticEndpoint("a", "b", "c"), List.of());
+        var c = new SemanticContract(
+                "c", new SemanticContractVersion("1.0.0"), "", entity,
+                List.of(), List.of(),
+                SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), null);
+        assertNull(c.explanation());
+    }
+
+    @Test
+    void contract_withExplanation_roundTrip() throws Exception {
+        var entity = new SemanticEntity("c", "", new SemanticEndpoint("a", "b", "c"), List.of());
+        var explanation = new SemanticContractExplanation(
+                "Team Alpha", "Use for reporting.", List.of("Caveat 1"),
+                "One row per day", List.of("shape1"),
+                new SemanticLineageHook("H1", "hook"),
+                new SemanticEntitlementBehavior("FULL", "full access"),
+                List.of("dim1"));
+        var c = new SemanticContract(
+                "c", new SemanticContractVersion("1.0.0"), "", entity,
+                List.of(new SemanticMeasure("m", "M", "SUM(m)", SemanticFieldType.DECIMAL, "", null)),
+                List.of(new SemanticDimension("d", "d", SemanticFieldType.STRING, "D", true, true, null)),
+                SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), explanation);
+
+        var restored = mapper.readValue(mapper.writeValueAsString(c), SemanticContract.class);
+        assertNotNull(restored.explanation());
+        assertEquals("Team Alpha", restored.explanation().owner());
+        assertEquals("Use for reporting.", restored.explanation().intendedUsage());
+    }
+
+    @Test
+    void contract_nullExplanation_omittedFromJson() throws Exception {
+        var entity = new SemanticEntity("c", "", new SemanticEndpoint("a", "b", "c"), List.of());
+        var c = new SemanticContract(
+                "c", new SemanticContractVersion("1.0.0"), "", entity,
+                List.of(), List.of(),
+                SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), null);
+
+        var json = mapper.writeValueAsString(c);
+        assertFalse(json.contains("explanation"), "null explanation must not appear in JSON");
+    }
+
+    // ── SemanticMeasure with explanation ───────────────────────────────────────
+
+    @Test
+    void measure_withExplanation_roundTrip() throws Exception {
+        var explanation = new SemanticMeasureExplanation(
+                "Daily PnL reporting.", List.of("Unrealized included"));
+        var m = new SemanticMeasure("pnl", "PnL", "SUM(pnl)", SemanticFieldType.DECIMAL,
+                "Sum of PnL", explanation);
+
+        var restored = mapper.readValue(mapper.writeValueAsString(m), SemanticMeasure.class);
+        assertNotNull(restored.explanation());
+        assertEquals("Daily PnL reporting.", restored.explanation().intendedUsage());
+        assertEquals(1, restored.explanation().caveats().size());
+    }
+
+    @Test
+    void measure_nullExplanation_omittedFromJson() throws Exception {
+        var m = new SemanticMeasure("pnl", "PnL", "SUM(pnl)", SemanticFieldType.DECIMAL, "", null);
+        var json = mapper.writeValueAsString(m);
+        assertFalse(json.contains("explanation"), "null explanation must not appear in JSON");
+    }
+
+    // ── SemanticDimension with explanation ─────────────────────────────────────
+
+    @Test
+    void dimension_withExplanation_roundTrip() throws Exception {
+        var explanation = new SemanticDimensionExplanation(
+                "Legal entity book code.", List.of("Changes during reorg"));
+        var d = new SemanticDimension("book", "book", SemanticFieldType.STRING,
+                "Trading Book", true, true, explanation);
+
+        var restored = mapper.readValue(mapper.writeValueAsString(d), SemanticDimension.class);
+        assertNotNull(restored.explanation());
+        assertEquals("Legal entity book code.", restored.explanation().description());
+    }
+
+    @Test
+    void dimension_nullExplanation_omittedFromJson() throws Exception {
+        var d = new SemanticDimension("book", "book", SemanticFieldType.STRING,
+                "Trading Book", true, true, null);
+        var json = mapper.writeValueAsString(d);
+        assertFalse(json.contains("explanation"), "null explanation must not appear in JSON");
+    }
+}

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/registry/ContractRegistryPopulatorTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/registry/ContractRegistryPopulatorTest.java
@@ -309,10 +309,11 @@ class ContractRegistryPopulatorTest {
                 name, new SemanticContractVersion("1.0.0"), "",
                 new SemanticEntity(name, "",
                         new SemanticEndpoint("c", "s", "t"), List.of()),
-                List.of(new SemanticMeasure("m", "M", "SUM(m)", SemanticFieldType.DECIMAL, "")),
-                List.of(new SemanticDimension("d", "d", SemanticFieldType.STRING, "D", true, true)),
+                List.of(new SemanticMeasure("m", "M", "SUM(m)", SemanticFieldType.DECIMAL, "", null)),
+                List.of(new SemanticDimension("d", "d", SemanticFieldType.STRING, "D", true, true, null)),
                 SemanticAccessPolicy.unrestricted(),
-                SemanticCachePolicy.none());
+                SemanticCachePolicy.none(),
+                null);
     }
 
     private static SemanticContract contractNoMeasures(String name) {
@@ -323,7 +324,8 @@ class ContractRegistryPopulatorTest {
                 List.of(),   // no measures → CONTRACT_NO_MEASURES warning
                 List.of(),
                 SemanticAccessPolicy.unrestricted(),
-                SemanticCachePolicy.none());
+                SemanticCachePolicy.none(),
+                null);
     }
 
     private static SemanticContract contractWithDatasetVersionCache(String name) {
@@ -333,7 +335,8 @@ class ContractRegistryPopulatorTest {
                         new SemanticEndpoint("c", "s", "t"), List.of()),
                 List.of(), List.of(),
                 SemanticAccessPolicy.unrestricted(),
-                new SemanticCachePolicy(SemanticCacheStrategy.DATASET_VERSION, null, List.of()));
+                new SemanticCachePolicy(SemanticCacheStrategy.DATASET_VERSION, null, List.of()),
+                null);
     }
 
     private Path copyFixture(Path tmp, String fixtureResource, String destName)

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/registry/ContractRegistryTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/registry/ContractRegistryTest.java
@@ -42,7 +42,8 @@ class ContractRegistryTest {
                 List.of(),
                 List.of(),
                 SemanticAccessPolicy.unrestricted(),
-                SemanticCachePolicy.none());
+                SemanticCachePolicy.none(),
+                null);
     }
 
     // ── register / findByName ─────────────────────────────────────────────────

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/RegistrySemanticContractResolverTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/RegistrySemanticContractResolverTest.java
@@ -241,9 +241,10 @@ class RegistrySemanticContractResolverTest {
                 name, new SemanticContractVersion("1.0.0"), "",
                 new SemanticEntity(name, "",
                         new SemanticEndpoint("c", "s", "t"), List.of()),
-                List.of(new SemanticMeasure("m", "M", "SUM(m)", SemanticFieldType.DECIMAL, "")),
-                List.of(new SemanticDimension("d", "d", SemanticFieldType.STRING, "D", true, true)),
+                List.of(new SemanticMeasure("m", "M", "SUM(m)", SemanticFieldType.DECIMAL, "", null)),
+                List.of(new SemanticDimension("d", "d", SemanticFieldType.STRING, "D", true, true, null)),
                 SemanticAccessPolicy.unrestricted(),
-                SemanticCachePolicy.none());
+                SemanticCachePolicy.none(),
+                null);
     }
 }

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/ServiceBoundaryTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/ServiceBoundaryTest.java
@@ -197,7 +197,7 @@ class ServiceBoundaryTest {
     static SemanticContract minimalContract() {
         var entity = new SemanticEntity("c", "", new SemanticEndpoint("cat", "sch", "tbl"), List.of());
         return new SemanticContract("c", new SemanticContractVersion("1.0.0"), "", entity,
-                List.of(), List.of(), SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none());
+                List.of(), List.of(), SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), null);
     }
 
     @Test

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/validation/ContractValidatorTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/validation/ContractValidatorTest.java
@@ -417,7 +417,8 @@ class ContractValidatorTest {
                         List.of()),
                 measures, dimensions,
                 SemanticAccessPolicy.unrestricted(),
-                SemanticCachePolicy.none());
+                SemanticCachePolicy.none(),
+                null);
     }
 
     private static SemanticContract contractWithCachePolicy(String name, SemanticCachePolicy policy) {
@@ -427,7 +428,7 @@ class ContractValidatorTest {
                         new SemanticEndpoint("c", "s", "t"),
                         List.of(new SemanticRuleRef("R1", "r"))),
                 measures("m"), dimensions("d"),
-                SemanticAccessPolicy.unrestricted(), policy);
+                SemanticAccessPolicy.unrestricted(), policy, null);
     }
 
     private static List<SemanticMeasure> measures(String... names) {
@@ -440,11 +441,11 @@ class ContractValidatorTest {
 
     private static SemanticMeasure measure(String name) {
         return new SemanticMeasure(name, name, "SUM(" + name + ")",
-                SemanticFieldType.DECIMAL, "");
+                SemanticFieldType.DECIMAL, "", null);
     }
 
     private static SemanticDimension dimension(String name) {
-        return new SemanticDimension(name, name, SemanticFieldType.STRING, name, true, true);
+        return new SemanticDimension(name, name, SemanticFieldType.STRING, name, true, true, null);
     }
 
     private static SemanticQueryContract queryContract(String name, String sourceContract,

--- a/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticContractMetadataControllerTest.java
+++ b/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticContractMetadataControllerTest.java
@@ -183,7 +183,8 @@ class SemanticContractMetadataControllerTest {
                         new SemanticEndpoint("c", "s", "t"), List.of()),
                 List.of(), List.of(),
                 SemanticAccessPolicy.unrestricted(),
-                SemanticCachePolicy.none());
+                SemanticCachePolicy.none(),
+                null);
         Mockito.when(registry.list()).thenReturn(List.of(noMeasures));
 
         mockMvc.perform(get("/api/semantic/contracts/validation"))
@@ -242,12 +243,13 @@ class SemanticContractMetadataControllerTest {
                 new SemanticEntity("mxl_risk", "",
                         new SemanticEndpoint("main", "risk", "gold_risk"), List.of()),
                 List.of(
-                        new SemanticMeasure("pnl",       "PnL",   "SUM(pnl)",   SemanticFieldType.DECIMAL, ""),
-                        new SemanticMeasure("delta_risk", "Delta", "SUM(delta)", SemanticFieldType.DECIMAL, "")),
+                        new SemanticMeasure("pnl",       "PnL",   "SUM(pnl)",   SemanticFieldType.DECIMAL, "", null),
+                        new SemanticMeasure("delta_risk", "Delta", "SUM(delta)", SemanticFieldType.DECIMAL, "", null)),
                 List.of(
-                        new SemanticDimension("book", "book", SemanticFieldType.STRING, "Book", true, true)),
+                        new SemanticDimension("book", "book", SemanticFieldType.STRING, "Book", true, true, null)),
                 SemanticAccessPolicy.unrestricted(),
-                SemanticCachePolicy.ttl(7200L));
+                SemanticCachePolicy.ttl(7200L),
+                null);
     }
 
     private static SemanticContract minimalContract(String name) {
@@ -255,10 +257,11 @@ class SemanticContractMetadataControllerTest {
                 name, new SemanticContractVersion("1.0.0"), "",
                 new SemanticEntity(name, "",
                         new SemanticEndpoint("c", "s", "t"), List.of()),
-                List.of(new SemanticMeasure("m", "M", "SUM(m)", SemanticFieldType.DECIMAL, "")),
-                List.of(new SemanticDimension("d", "d", SemanticFieldType.STRING, "D", true, true)),
+                List.of(new SemanticMeasure("m", "M", "SUM(m)", SemanticFieldType.DECIMAL, "", null)),
+                List.of(new SemanticDimension("d", "d", SemanticFieldType.STRING, "D", true, true, null)),
                 SemanticAccessPolicy.unrestricted(),
-                SemanticCachePolicy.none());
+                SemanticCachePolicy.none(),
+                null);
     }
 
     private static SemanticContract contractWithCache(String name, SemanticCachePolicy policy) {
@@ -266,9 +269,10 @@ class SemanticContractMetadataControllerTest {
                 name, new SemanticContractVersion("1.0.0"), "",
                 new SemanticEntity(name, "",
                         new SemanticEndpoint("c", "s", "t"), List.of()),
-                List.of(new SemanticMeasure("m", "M", "SUM(m)", SemanticFieldType.DECIMAL, "")),
-                List.of(new SemanticDimension("d", "d", SemanticFieldType.STRING, "D", true, true)),
+                List.of(new SemanticMeasure("m", "M", "SUM(m)", SemanticFieldType.DECIMAL, "", null)),
+                List.of(new SemanticDimension("d", "d", SemanticFieldType.STRING, "D", true, true, null)),
                 SemanticAccessPolicy.unrestricted(),
-                policy);
+                policy,
+                null);
     }
 }


### PR DESCRIPTION
## Summary

- Adds five new value objects for ADR-012 buddy chat explanation metadata: `SemanticContractExplanation`, `SemanticMeasureExplanation`, `SemanticDimensionExplanation`, `SemanticLineageHook` (placeholder), and `SemanticEntitlementBehavior` (placeholder)
- Extends `SemanticContract`, `SemanticMeasure`, and `SemanticDimension` with a nullable `explanation` field annotated `@JsonInclude(NON_NULL)` so existing minimal fixtures and JSON round-trip tests are unaffected
- No buddy-chat runtime, LLM integration, or REST API endpoints added

Closes #72

## Test plan

- [x] 31 new tests in `SemanticExplanationMetadataTest` covering construction, field access, defensive copying, JSON round-trips, and backward compatibility
- [x] All 409 existing `skadi-semantic` tests pass (no regressions)
- [x] All 116 existing `skadi-server` tests pass (no regressions)
- [x] Existing JSON fixture `sample-contract.json` round-trip test unchanged — null `explanation` fields omitted from serialization via `@JsonInclude(NON_NULL)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)