### PR TITLE
test: add enriched semantic contract metadata fixtures (E1.2)

### DIFF
--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/loader/ContractLoaderTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/loader/ContractLoaderTest.java
@@ -1,7 +1,8 @@
 package org.iceforge.skadi.semantic.loader;
 
-import org.iceforge.skadi.semantic.contract.SemanticContract;
 import org.iceforge.skadi.semantic.contract.SemanticCacheStrategy;
+import org.iceforge.skadi.semantic.contract.SemanticContract;
+import org.iceforge.skadi.semantic.contract.SemanticDimension;
 import org.iceforge.skadi.semantic.contract.SemanticMeasure;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -251,6 +252,203 @@ class ContractLoaderTest {
     @Test
     void loadAll_nullList_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> loader.loadAll(null));
+    }
+
+    // ── Enriched fixture — explanation metadata ────────────────────────────────
+
+    @Test
+    void enriched_loadsSuccessfully() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            SemanticContract c = loader.load(in);
+            assertEquals("cib_var", c.name());
+            assertEquals("2.0.0", c.version().value());
+            assertEquals(2, c.measures().size());
+            assertEquals(4, c.dimensions().size());
+        }
+    }
+
+    @Test
+    void enriched_contractExplanation_ownerAndUsage() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            var exp = loader.load(in).explanation();
+            assertNotNull(exp, "enriched contract must carry explanation metadata");
+            assertEquals("CIB Risk Technology", exp.owner());
+            assertNotNull(exp.intendedUsage());
+            assertTrue(exp.intendedUsage().contains("Basel III"),
+                    "intendedUsage should mention Basel III");
+        }
+    }
+
+    @Test
+    void enriched_contractExplanation_caveats() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            var caveats = loader.load(in).explanation().caveats();
+            assertNotNull(caveats);
+            assertEquals(3, caveats.size());
+            assertTrue(caveats.get(0).contains("8 AM UTC"),
+                    "first caveat should mention data availability time");
+        }
+    }
+
+    @Test
+    void enriched_contractExplanation_grain() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            var grain = loader.load(in).explanation().grain();
+            assertNotNull(grain);
+            assertTrue(grain.contains("legal entity"), "grain should describe row-level granularity");
+        }
+    }
+
+    @Test
+    void enriched_contractExplanation_outputShapes() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            var shapes = loader.load(in).explanation().outputShapes();
+            assertNotNull(shapes);
+            assertEquals(3, shapes.size());
+            assertTrue(shapes.contains("var_by_legal_entity"));
+            assertTrue(shapes.contains("var_by_risk_class"));
+        }
+    }
+
+    @Test
+    void enriched_contractExplanation_lineageHook() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            var hook = loader.load(in).explanation().lineageHook();
+            assertNotNull(hook);
+            assertEquals("RISK-LIN-VAR-01", hook.hookId());
+            assertNotNull(hook.description());
+        }
+    }
+
+    @Test
+    void enriched_contractExplanation_entitlementBehavior() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            var eb = loader.load(in).explanation().entitlementBehavior();
+            assertNotNull(eb);
+            assertEquals("ROW_FILTER", eb.mode());
+            assertNotNull(eb.description());
+        }
+    }
+
+    @Test
+    void enriched_contractExplanation_validGroupingPaths() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            var paths = loader.load(in).explanation().validGroupingPaths();
+            assertNotNull(paths);
+            assertEquals(7, paths.size());
+            assertTrue(paths.contains("cob_date"));
+            assertTrue(paths.contains("legal_entity,risk_class"));
+        }
+    }
+
+    @Test
+    void enriched_measureExplanation_var1d() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            SemanticMeasure var1d = loader.load(in).measures().stream()
+                    .filter(m -> m.name().equals("var_1d"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("var_1d measure not found"));
+            assertNotNull(var1d.explanation(), "var_1d must carry explanation metadata");
+            assertNotNull(var1d.explanation().intendedUsage());
+            assertTrue(var1d.explanation().intendedUsage().contains("regulatory capital"),
+                    "intendedUsage should mention regulatory capital");
+            assertNotNull(var1d.explanation().caveats());
+            assertEquals(2, var1d.explanation().caveats().size());
+        }
+    }
+
+    @Test
+    void enriched_measureExplanation_var10d() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            SemanticMeasure var10d = loader.load(in).measures().stream()
+                    .filter(m -> m.name().equals("var_10d"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("var_10d measure not found"));
+            assertNotNull(var10d.explanation());
+            assertTrue(var10d.explanation().intendedUsage().contains("Basel III"));
+            assertEquals(2, var10d.explanation().caveats().size());
+        }
+    }
+
+    @Test
+    void enriched_dimensionExplanation_legalEntity() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            SemanticDimension le = loader.load(in).dimensions().stream()
+                    .filter(d -> d.name().equals("legal_entity"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("legal_entity dimension not found"));
+            assertNotNull(le.explanation());
+            assertNotNull(le.explanation().description());
+            assertTrue(le.explanation().description().contains("legal entity"),
+                    "description should describe the legal entity code");
+            assertEquals(1, le.explanation().caveats().size());
+        }
+    }
+
+    @Test
+    void enriched_dimensionExplanation_riskClass() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            SemanticDimension rc = loader.load(in).dimensions().stream()
+                    .filter(d -> d.name().equals("risk_class"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("risk_class dimension not found"));
+            assertNotNull(rc.explanation());
+            assertTrue(rc.explanation().description().contains("FRTB"));
+        }
+    }
+
+    @Test
+    void enriched_dimensionExplanation_desk_groupableFalse() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            SemanticDimension desk = loader.load(in).dimensions().stream()
+                    .filter(d -> d.name().equals("desk"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("desk dimension not found"));
+            assertFalse(desk.groupable(), "desk dimension must not be groupable");
+            assertNotNull(desk.explanation());
+            assertNotNull(desk.explanation().description());
+        }
+    }
+
+    @Test
+    void enriched_accessPolicy_hasThreeRoles() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            var policy = loader.load(in).accessPolicy();
+            assertEquals(3, policy.allowedRoles().size());
+            assertTrue(policy.allowedRoles().stream()
+                    .anyMatch(r -> r.name().equals("regulatory_reporting")));
+        }
+    }
+
+    @Test
+    void enriched_cachePolicyIsTtl14400() throws Exception {
+        try (InputStream in = stream("/fixtures/enriched-contract.json")) {
+            var cache = loader.load(in).cachePolicy();
+            assertEquals(SemanticCacheStrategy.TTL, cache.strategy());
+            assertEquals(14400L, cache.ttlSeconds());
+        }
+    }
+
+    @Test
+    void enriched_minimalFixture_unaffected() throws Exception {
+        // Existing minimal fixture must still load correctly after adding the enriched fixture.
+        try (InputStream in = stream("/fixtures/sample-contract.json")) {
+            SemanticContract c = loader.load(in);
+            assertEquals("mxl_risk", c.name());
+            assertNull(c.explanation(), "minimal fixture must not carry explanation metadata");
+        }
+    }
+
+    @Test
+    void enriched_loadAll_bothFixturesLoad(@TempDir Path tmp) throws Exception {
+        Path minimal  = copyFixtureToTempDir(tmp, "sample-contract.json",  "minimal.json");
+        Path enriched = copyFixtureToTempDir(tmp, "enriched-contract.json", "enriched.json");
+
+        var contracts = loader.loadAll(List.of(minimal, enriched));
+        assertEquals(2, contracts.size());
+        assertEquals("mxl_risk", contracts.get(0).name());
+        assertEquals("cib_var",  contracts.get(1).name());
+        assertNotNull(contracts.get(1).explanation());
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────

--- a/skadi-semantic/src/test/resources/fixtures/enriched-contract.json
+++ b/skadi-semantic/src/test/resources/fixtures/enriched-contract.json
@@ -1,0 +1,165 @@
+{
+  "name": "cib_var",
+  "version": {
+    "value": "2.0.0"
+  },
+  "description": "CIB VaR gold layer — daily 1-day and 10-day Value at Risk by legal entity and risk class",
+  "entity": {
+    "name": "cib_var",
+    "description": "CIB VaR gold layer physical table",
+    "endpoint": {
+      "catalog": "main",
+      "schema": "risk",
+      "table": "gold_var"
+    },
+    "ruleRefs": [
+      {
+        "ruleId": "BCBS239-01",
+        "description": "Data lineage and aggregation risk data requirement"
+      },
+      {
+        "ruleId": "FRTB-SA-01",
+        "description": "FRTB Standardised Approach reporting requirement"
+      }
+    ]
+  },
+  "measures": [
+    {
+      "name": "var_1d",
+      "label": "1-Day VaR (99%)",
+      "expression": "SUM(var_1d_99)",
+      "type": "DECIMAL",
+      "description": "1-day Value at Risk at 99% confidence level",
+      "explanation": {
+        "intendedUsage": "Use for daily regulatory capital consumption reporting. Do not aggregate across legal entities without FX normalisation.",
+        "caveats": [
+          "Assumes normal distribution — tail events may exceed stated VaR",
+          "Reported in USD; local currency positions are converted at end-of-day FX rates"
+        ]
+      }
+    },
+    {
+      "name": "var_10d",
+      "label": "10-Day VaR (99%)",
+      "expression": "SUM(var_10d_99)",
+      "type": "DECIMAL",
+      "description": "10-day Value at Risk at 99% confidence level (Basel scaling)",
+      "explanation": {
+        "intendedUsage": "Use for Basel III capital requirement calculations. Derived from 1-day VaR by the square-root-of-time rule.",
+        "caveats": [
+          "Not suitable for intraday risk monitoring",
+          "Regulatory use only — not for internal limit management"
+        ]
+      }
+    }
+  ],
+  "dimensions": [
+    {
+      "name": "cob_date",
+      "column": "cob_date",
+      "type": "DATE",
+      "label": "Close of Business Date",
+      "filterable": true,
+      "groupable": true,
+      "explanation": {
+        "description": "The business date for which risk figures are calculated, typically T-1.",
+        "caveats": [
+          "Non-business days are excluded; the previous COB date carries forward"
+        ]
+      }
+    },
+    {
+      "name": "legal_entity",
+      "column": "legal_entity_code",
+      "type": "STRING",
+      "label": "Legal Entity",
+      "filterable": true,
+      "groupable": true,
+      "explanation": {
+        "description": "Short code identifying the regulated legal entity (e.g. CIBUK, CIBNA).",
+        "caveats": [
+          "Legal entity codes may change during restructuring; historical codes are preserved"
+        ]
+      }
+    },
+    {
+      "name": "risk_class",
+      "column": "risk_class",
+      "type": "STRING",
+      "label": "Risk Class",
+      "filterable": true,
+      "groupable": true,
+      "explanation": {
+        "description": "FRTB risk class (e.g. IR, FX, EQ, CR, CM) to which the position is attributed.",
+        "caveats": [
+          "Risk class assignment follows FRTB SA bucketing rules and may differ from internal classifications"
+        ]
+      }
+    },
+    {
+      "name": "desk",
+      "column": "desk_id",
+      "type": "STRING",
+      "label": "Trading Desk",
+      "filterable": true,
+      "groupable": false,
+      "explanation": {
+        "description": "Internal desk identifier. Grouping by desk is not permitted for regulatory reporting.",
+        "caveats": [
+          "Desk granularity is below the level required for regulatory aggregation"
+        ]
+      }
+    }
+  ],
+  "accessPolicy": {
+    "allowedRoles": [
+      {"name": "risk_analyst"},
+      {"name": "risk_viewer"},
+      {"name": "regulatory_reporting"}
+    ],
+    "allowedPrincipals": [
+      {"type": "GROUP", "name": "cib-risk-team"},
+      {"type": "GROUP", "name": "regulatory-reporting-team"}
+    ],
+    "ruleRefs": [
+      {"ruleId": "GOV-FRTB-01", "description": "FRTB data access governance policy"}
+    ]
+  },
+  "cachePolicy": {
+    "strategy": "TTL",
+    "ttlSeconds": 14400,
+    "ruleRefs": []
+  },
+  "explanation": {
+    "owner": "CIB Risk Technology",
+    "intendedUsage": "Use for daily regulatory VaR reporting under Basel III and FRTB. Suitable for legal-entity-level and risk-class-level aggregation. Not suitable for intraday risk monitoring.",
+    "caveats": [
+      "Data is available after 8 AM UTC; early-morning queries may return the previous COB",
+      "FX rates used for normalisation are end-of-day rates from the market data golden source",
+      "Historical restatements are marked via the 'restated' flag on the underlying table"
+    ],
+    "grain": "One row per legal entity, risk class, desk, and close-of-business date",
+    "outputShapes": [
+      "var_by_legal_entity",
+      "var_by_risk_class",
+      "var_by_legal_entity_and_risk_class"
+    ],
+    "lineageHook": {
+      "hookId": "RISK-LIN-VAR-01",
+      "description": "BCBS 239 compliant lineage hook for CIB VaR aggregation pipeline"
+    },
+    "entitlementBehavior": {
+      "mode": "ROW_FILTER",
+      "description": "Rows are filtered by the caller's legal entity entitlement set; cross-entity aggregation requires the cib-risk-team group membership"
+    },
+    "validGroupingPaths": [
+      "cob_date",
+      "legal_entity",
+      "risk_class",
+      "cob_date,legal_entity",
+      "cob_date,risk_class",
+      "legal_entity,risk_class",
+      "cob_date,legal_entity,risk_class"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `enriched-contract.json` — a CIB VaR contract (`cib_var`, version 2.0.0) with fully populated explanation metadata at contract, measure, and dimension level
- Adds 17 new loader tests in `ContractLoaderTest` asserting every explanation metadata field survives JSON round-trip through the `JsonContractLoader`
- Existing minimal `sample-contract.json` fixture and its 24 loader tests are unchanged

Closes #73

## What the enriched fixture covers

| Scope | Fields represented |
|---|---|
| Contract | owner, intendedUsage (3), caveats (3), grain, outputShapes (3), lineageHook (hookId + description), entitlementBehavior (mode + description), validGroupingPaths (7) |
| Measure `var_1d` | intendedUsage, caveats (2) |
| Measure `var_10d` | intendedUsage, caveats (2) |
| Dimension `legal_entity` | description, caveats (1) |
| Dimension `risk_class` | description, caveats (1) |
| Dimension `desk` (groupable=false) | description, caveats (1) |
| Dimension `cob_date` | description, caveats (1) |

## Test plan

- [x] 17 new loader tests covering contract-level, measure-level, and dimension-level metadata preservation
- [x] Backward-compatibility test: minimal `sample-contract.json` still loads with `explanation == null`
- [x] `loadAll` test: both fixtures load together successfully
- [x] All 426 `skadi-semantic` tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)