### PR TITLE
feat: add semantic request validation model (E1.7)

### DIFF
--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationOutcome.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationOutcome.java
@@ -1,0 +1,109 @@
+package org.iceforge.skadi.semantic.request;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The outcome of a semantic request validation.
+ *
+ * <p>{@link #allowed()} is the primary decision: {@code true} means the operation
+ * is permitted, {@code false} means it is denied. {@link #reasonCode()} gives the
+ * specific machine-readable reason, and {@link #message()} provides a user-safe
+ * explanation suitable for display in buddy-chat or dashboard UI.
+ *
+ * <p>Optional fields ({@link #contractId()}, {@link #invalidFields()}) carry
+ * diagnostic detail when available.
+ *
+ * <p>Use the static factories rather than constructing directly:
+ * <ul>
+ *   <li>{@link #allowed(String, String)} — permitted outcome</li>
+ *   <li>{@link #denied(SemanticValidationReasonCode, String)} — denied with reason</li>
+ *   <li>{@link #denied(SemanticValidationReasonCode, String, String, List)} — denied with context</li>
+ * </ul>
+ *
+ * <pre>{@code
+ * // Permitted
+ * SemanticValidationOutcome.allowed("cib_var", "legal_entity can be used as a GROUP BY dimension.");
+ *
+ * // Denied — dimension exists but is not groupable
+ * SemanticValidationOutcome.denied(
+ *     SemanticValidationReasonCode.DIMENSION_NOT_GROUPABLE,
+ *     "The 'desk' dimension is not available for grouping in regulatory reports.",
+ *     "cib_var",
+ *     List.of("desk"));
+ *
+ * // Denied — entitlement placeholder
+ * SemanticValidationOutcome.denied(
+ *     SemanticValidationReasonCode.DENIED_BY_ENTITLEMENT,
+ *     "You do not have access to cross-entity aggregation for this contract.");
+ * }</pre>
+ */
+public record SemanticValidationOutcome(
+        boolean allowed,
+        SemanticValidationReasonCode reasonCode,
+        String message,
+        String contractId,
+        List<String> invalidFields) {
+
+    /**
+     * @param allowed       {@code true} if the operation is permitted
+     * @param reasonCode    the machine-readable reason; must not be null
+     * @param message       user-safe explanation; must not be null
+     * @param contractId    the contract this outcome applies to; may be null
+     * @param invalidFields the specific fields that caused denial; may be null;
+     *                      defensively copied when non-null
+     */
+    public SemanticValidationOutcome {
+        Objects.requireNonNull(reasonCode, "reasonCode must not be null");
+        Objects.requireNonNull(message,    "message must not be null");
+        if (allowed && !reasonCode.isAllowed()) {
+            throw new IllegalArgumentException(
+                    "allowed outcome must use ALLOWED reason code, got: " + reasonCode);
+        }
+        if (!allowed && reasonCode.isAllowed()) {
+            throw new IllegalArgumentException(
+                    "denied outcome must not use ALLOWED reason code");
+        }
+        invalidFields = invalidFields == null ? null : List.copyOf(invalidFields);
+    }
+
+    // ── Static factories ───────────────────────────────────────────────────────
+
+    /**
+     * Returns an allowed outcome for the given contract.
+     *
+     * @param contractId the contract that was checked; must not be null
+     * @param message    user-safe explanation of why the operation is allowed
+     */
+    public static SemanticValidationOutcome allowed(String contractId, String message) {
+        Objects.requireNonNull(contractId, "contractId must not be null");
+        return new SemanticValidationOutcome(
+                true, SemanticValidationReasonCode.ALLOWED, message, contractId, null);
+    }
+
+    /**
+     * Returns a denied outcome with no contract or field context.
+     *
+     * @param reasonCode the reason for denial; must not be null and must not be ALLOWED
+     * @param message    user-safe explanation of why the operation is denied
+     */
+    public static SemanticValidationOutcome denied(SemanticValidationReasonCode reasonCode,
+                                                   String message) {
+        return new SemanticValidationOutcome(false, reasonCode, message, null, null);
+    }
+
+    /**
+     * Returns a denied outcome with contract and invalid-field context.
+     *
+     * @param reasonCode    the reason for denial; must not be null and must not be ALLOWED
+     * @param message       user-safe explanation of why the operation is denied
+     * @param contractId    the contract that was checked; may be null
+     * @param invalidFields the fields that triggered the denial; may be null
+     */
+    public static SemanticValidationOutcome denied(SemanticValidationReasonCode reasonCode,
+                                                   String message,
+                                                   String contractId,
+                                                   List<String> invalidFields) {
+        return new SemanticValidationOutcome(false, reasonCode, message, contractId, invalidFields);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationReasonCode.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationReasonCode.java
@@ -1,0 +1,116 @@
+package org.iceforge.skadi.semantic.request;
+
+/**
+ * Reason codes for a {@link SemanticValidationOutcome}.
+ *
+ * <p>Each code maps to one explicit outcome category, making validation results
+ * programmatically testable and safe for use in user-facing messages without
+ * leaking internal details.
+ *
+ * <h2>Allowed</h2>
+ * <ul>
+ *   <li>{@link #ALLOWED} — the requested operation is permitted</li>
+ * </ul>
+ *
+ * <h2>Not-found denials</h2>
+ * <ul>
+ *   <li>{@link #UNKNOWN_CONTRACT} — the requested contract is not in the registry</li>
+ *   <li>{@link #UNKNOWN_MEASURE} — the named measure is not defined in the contract</li>
+ *   <li>{@link #UNKNOWN_DIMENSION} — the named dimension is not defined in the contract</li>
+ * </ul>
+ *
+ * <h2>Governance denials</h2>
+ * <ul>
+ *   <li>{@link #DIMENSION_NOT_GROUPABLE} — the dimension exists but groupable is false</li>
+ *   <li>{@link #DIMENSION_NOT_FILTERABLE} — the dimension exists but filterable is false</li>
+ *   <li>{@link #INVALID_GROUPING_PATH} — the requested combination is not in validGroupingPaths</li>
+ *   <li>{@link #UNSUPPORTED_GRAIN} — the requested grain is not supported by this contract</li>
+ *   <li>{@link #UNSUPPORTED_OUTPUT_SHAPE} — the requested output shape is not in the contract</li>
+ * </ul>
+ *
+ * <h2>Entitlement (placeholder)</h2>
+ * <ul>
+ *   <li>{@link #DENIED_BY_ENTITLEMENT} — access denied by entitlement policy; enforcement
+ *       is deferred but the seam exists for future use</li>
+ * </ul>
+ *
+ * <h2>Request quality denials</h2>
+ * <ul>
+ *   <li>{@link #AMBIGUOUS_REQUEST} — the request cannot be resolved to a single subject</li>
+ *   <li>{@link #UNSUPPORTED_REQUEST} — the request type is not supported for this contract</li>
+ * </ul>
+ */
+public enum SemanticValidationReasonCode {
+
+    // ── Allowed ────────────────────────────────────────────────────────────────
+
+    /** The requested operation is permitted by the contract and its governance metadata. */
+    ALLOWED,
+
+    // ── Not-found denials ──────────────────────────────────────────────────────
+
+    /** The referenced contract name is not registered in the active contract registry. */
+    UNKNOWN_CONTRACT,
+
+    /** The referenced measure name is not defined in the named contract. */
+    UNKNOWN_MEASURE,
+
+    /** The referenced dimension name is not defined in the named contract. */
+    UNKNOWN_DIMENSION,
+
+    // ── Governance denials ─────────────────────────────────────────────────────
+
+    /** The dimension exists but its {@code groupable} flag is {@code false}. */
+    DIMENSION_NOT_GROUPABLE,
+
+    /** The dimension exists but its {@code filterable} flag is {@code false}. */
+    DIMENSION_NOT_FILTERABLE,
+
+    /**
+     * The requested grouping path (combination of dimension names) is not present
+     * in the contract's {@code validGroupingPaths} list.
+     */
+    INVALID_GROUPING_PATH,
+
+    /**
+     * The requested grain does not match the grain declared in the contract's
+     * explanation metadata.
+     */
+    UNSUPPORTED_GRAIN,
+
+    /**
+     * The requested output shape is not listed in the contract's
+     * {@code outputShapes} explanation metadata.
+     */
+    UNSUPPORTED_OUTPUT_SHAPE,
+
+    // ── Entitlement placeholder ────────────────────────────────────────────────
+
+    /**
+     * Access denied by entitlement policy.
+     *
+     * <p>This is a placeholder seam for future entitlement enforcement. The
+     * entitlement behavior model ({@link org.iceforge.skadi.semantic.contract.SemanticEntitlementBehavior})
+     * carries the mode and description; policy enforcement is deferred.
+     */
+    DENIED_BY_ENTITLEMENT,
+
+    // ── Request quality denials ────────────────────────────────────────────────
+
+    /**
+     * The request could not be resolved to a single unambiguous subject
+     * (e.g. a term matches multiple measures or dimensions).
+     */
+    AMBIGUOUS_REQUEST,
+
+    /**
+     * The request type is not supported for this contract
+     * (e.g. grain validation requested but no grain is defined).
+     */
+    UNSUPPORTED_REQUEST;
+
+    /** Returns {@code true} if this code represents a successful (allowed) outcome. */
+    public boolean isAllowed() {
+        return this == ALLOWED;
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationRequest.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationRequest.java
@@ -1,0 +1,48 @@
+package org.iceforge.skadi.semantic.request;
+
+import java.util.Objects;
+
+/**
+ * A request to validate whether a specific semantic operation is permitted
+ * under the governed semantic model.
+ *
+ * <p>Validation is contract-scoped: the caller names a contract and a subject
+ * (e.g. a measure name, dimension name, grouping path) along with the type of
+ * operation being requested. The validation service checks the contract's
+ * governance metadata and returns a {@link SemanticValidationOutcome}.
+ *
+ * <p>This record is the input to validation only — it does not execute SQL,
+ * call Databricks, or query any cache.
+ *
+ * <p>Examples:
+ * <pre>{@code
+ * // Can I group by desk?
+ * new SemanticValidationRequest("cib_var", SemanticValidationRequestType.DIMENSION_GROUPING, "desk");
+ *
+ * // Can I filter by legal entity?
+ * new SemanticValidationRequest("cib_var", SemanticValidationRequestType.DIMENSION_FILTER, "legal_entity");
+ *
+ * // Is this grouping path valid?
+ * new SemanticValidationRequest("cib_var", SemanticValidationRequestType.GROUPING_PATH, "cob_date,legal_entity");
+ * }</pre>
+ */
+public record SemanticValidationRequest(
+        String contractId,
+        SemanticValidationRequestType requestType,
+        String subjectId) {
+
+    /**
+     * @param contractId  the name of the contract to validate against; must not be null or blank
+     * @param requestType the kind of operation being validated; must not be null
+     * @param subjectId   the subject of the validation (measure name, dimension name,
+     *                    grouping path, output shape name, or grain string);
+     *                    must not be null or blank
+     */
+    public SemanticValidationRequest {
+        Objects.requireNonNull(contractId,   "contractId must not be null");
+        Objects.requireNonNull(requestType,  "requestType must not be null");
+        Objects.requireNonNull(subjectId,    "subjectId must not be null");
+        if (contractId.isBlank())  throw new IllegalArgumentException("contractId must not be blank");
+        if (subjectId.isBlank())   throw new IllegalArgumentException("subjectId must not be blank");
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationRequestType.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationRequestType.java
@@ -1,0 +1,26 @@
+package org.iceforge.skadi.semantic.request;
+
+/**
+ * Classifies the kind of semantic operation being validated in a
+ * {@link SemanticValidationRequest}.
+ */
+public enum SemanticValidationRequestType {
+
+    /** Validate whether a named measure is accessible and defined in the contract. */
+    MEASURE_ACCESS,
+
+    /** Validate whether a named dimension may be used as a GROUP BY dimension. */
+    DIMENSION_GROUPING,
+
+    /** Validate whether a named dimension may be used as a filter predicate. */
+    DIMENSION_FILTER,
+
+    /** Validate whether a comma-joined path of dimension names is a valid grouping combination. */
+    GROUPING_PATH,
+
+    /** Validate whether a named output shape is declared for this contract. */
+    OUTPUT_SHAPE,
+
+    /** Validate whether a stated grain is consistent with the contract's grain declaration. */
+    GRAIN
+}

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/request/SemanticValidationModelTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/request/SemanticValidationModelTest.java
@@ -1,0 +1,246 @@
+package org.iceforge.skadi.semantic.request;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the semantic request validation model types.
+ *
+ * <p>No Spring context, no SQL, no external services.
+ */
+class SemanticValidationModelTest {
+
+    // ── SemanticValidationReasonCode ───────────────────────────────────────────
+
+    @Test
+    void reasonCode_allowed_isAllowed() {
+        assertTrue(SemanticValidationReasonCode.ALLOWED.isAllowed());
+    }
+
+    @Test
+    void reasonCode_allDenialCodes_areNotAllowed() {
+        for (var code : SemanticValidationReasonCode.values()) {
+            if (code != SemanticValidationReasonCode.ALLOWED) {
+                assertFalse(code.isAllowed(), code + " should not be allowed");
+            }
+        }
+    }
+
+    @Test
+    void reasonCode_allExpectedCodesPresent() {
+        var codes = List.of(SemanticValidationReasonCode.values());
+        assertTrue(codes.contains(SemanticValidationReasonCode.ALLOWED));
+        assertTrue(codes.contains(SemanticValidationReasonCode.UNKNOWN_CONTRACT));
+        assertTrue(codes.contains(SemanticValidationReasonCode.UNKNOWN_MEASURE));
+        assertTrue(codes.contains(SemanticValidationReasonCode.UNKNOWN_DIMENSION));
+        assertTrue(codes.contains(SemanticValidationReasonCode.DIMENSION_NOT_GROUPABLE));
+        assertTrue(codes.contains(SemanticValidationReasonCode.DIMENSION_NOT_FILTERABLE));
+        assertTrue(codes.contains(SemanticValidationReasonCode.INVALID_GROUPING_PATH));
+        assertTrue(codes.contains(SemanticValidationReasonCode.UNSUPPORTED_GRAIN));
+        assertTrue(codes.contains(SemanticValidationReasonCode.UNSUPPORTED_OUTPUT_SHAPE));
+        assertTrue(codes.contains(SemanticValidationReasonCode.DENIED_BY_ENTITLEMENT));
+        assertTrue(codes.contains(SemanticValidationReasonCode.AMBIGUOUS_REQUEST));
+        assertTrue(codes.contains(SemanticValidationReasonCode.UNSUPPORTED_REQUEST));
+    }
+
+    // ── SemanticValidationRequestType ──────────────────────────────────────────
+
+    @Test
+    void requestType_allExpectedTypesPresent() {
+        var types = List.of(SemanticValidationRequestType.values());
+        assertTrue(types.contains(SemanticValidationRequestType.MEASURE_ACCESS));
+        assertTrue(types.contains(SemanticValidationRequestType.DIMENSION_GROUPING));
+        assertTrue(types.contains(SemanticValidationRequestType.DIMENSION_FILTER));
+        assertTrue(types.contains(SemanticValidationRequestType.GROUPING_PATH));
+        assertTrue(types.contains(SemanticValidationRequestType.OUTPUT_SHAPE));
+        assertTrue(types.contains(SemanticValidationRequestType.GRAIN));
+    }
+
+    // ── SemanticValidationRequest ──────────────────────────────────────────────
+
+    @Test
+    void request_holdsFields() {
+        var req = new SemanticValidationRequest(
+                "cib_var", SemanticValidationRequestType.DIMENSION_GROUPING, "desk");
+        assertEquals("cib_var", req.contractId());
+        assertEquals(SemanticValidationRequestType.DIMENSION_GROUPING, req.requestType());
+        assertEquals("desk", req.subjectId());
+    }
+
+    @Test
+    void request_rejectsNullContractId() {
+        assertThrows(NullPointerException.class, () ->
+                new SemanticValidationRequest(null, SemanticValidationRequestType.MEASURE_ACCESS, "m"));
+    }
+
+    @Test
+    void request_rejectsNullRequestType() {
+        assertThrows(NullPointerException.class, () ->
+                new SemanticValidationRequest("c", null, "m"));
+    }
+
+    @Test
+    void request_rejectsNullSubjectId() {
+        assertThrows(NullPointerException.class, () ->
+                new SemanticValidationRequest("c", SemanticValidationRequestType.MEASURE_ACCESS, null));
+    }
+
+    @Test
+    void request_rejectsBlankContractId() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new SemanticValidationRequest("  ", SemanticValidationRequestType.MEASURE_ACCESS, "m"));
+    }
+
+    @Test
+    void request_rejectsBlankSubjectId() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new SemanticValidationRequest("c", SemanticValidationRequestType.MEASURE_ACCESS, ""));
+    }
+
+    @Test
+    void request_allRequestTypes_constructSuccessfully() {
+        for (var type : SemanticValidationRequestType.values()) {
+            assertDoesNotThrow(() ->
+                    new SemanticValidationRequest("cib_var", type, "subject"));
+        }
+    }
+
+    // ── SemanticValidationOutcome — allowed factory ────────────────────────────
+
+    @Test
+    void outcome_allowed_isAllowed() {
+        var o = SemanticValidationOutcome.allowed("cib_var", "Grouping by legal_entity is permitted.");
+        assertTrue(o.allowed());
+        assertEquals(SemanticValidationReasonCode.ALLOWED, o.reasonCode());
+        assertEquals("cib_var", o.contractId());
+        assertEquals("Grouping by legal_entity is permitted.", o.message());
+        assertNull(o.invalidFields());
+    }
+
+    @Test
+    void outcome_allowed_rejectsNullContractId() {
+        assertThrows(NullPointerException.class, () ->
+                SemanticValidationOutcome.allowed(null, "msg"));
+    }
+
+    // ── SemanticValidationOutcome — denied factories ───────────────────────────
+
+    @Test
+    void outcome_denied_simple_isNotAllowed() {
+        var o = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.UNKNOWN_CONTRACT,
+                "Contract 'foo' is not registered.");
+        assertFalse(o.allowed());
+        assertEquals(SemanticValidationReasonCode.UNKNOWN_CONTRACT, o.reasonCode());
+        assertEquals("Contract 'foo' is not registered.", o.message());
+        assertNull(o.contractId());
+        assertNull(o.invalidFields());
+    }
+
+    @Test
+    void outcome_denied_withContext_holdsAllFields() {
+        var o = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.DIMENSION_NOT_GROUPABLE,
+                "Grouping by 'desk' is not permitted for regulatory reporting.",
+                "cib_var",
+                List.of("desk"));
+        assertFalse(o.allowed());
+        assertEquals(SemanticValidationReasonCode.DIMENSION_NOT_GROUPABLE, o.reasonCode());
+        assertEquals("cib_var", o.contractId());
+        assertEquals(1, o.invalidFields().size());
+        assertEquals("desk", o.invalidFields().get(0));
+    }
+
+    @Test
+    void outcome_denied_invalidFields_defensivelyCopied() {
+        var mutable = new ArrayList<>(List.of("desk"));
+        var o = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.INVALID_GROUPING_PATH, "msg", "c", mutable);
+        mutable.add("book");
+        assertEquals(1, o.invalidFields().size());
+    }
+
+    @Test
+    void outcome_denied_invalidFields_unmodifiable() {
+        var o = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.DIMENSION_NOT_FILTERABLE, "msg", "c", List.of("d"));
+        assertThrows(UnsupportedOperationException.class, () -> o.invalidFields().add("extra"));
+    }
+
+    @Test
+    void outcome_denied_rejectsNullReasonCode() {
+        assertThrows(NullPointerException.class, () ->
+                SemanticValidationOutcome.denied(null, "msg"));
+    }
+
+    @Test
+    void outcome_denied_rejectsNullMessage() {
+        assertThrows(NullPointerException.class, () ->
+                SemanticValidationOutcome.denied(SemanticValidationReasonCode.UNKNOWN_MEASURE, null));
+    }
+
+    // ── SemanticValidationOutcome — invariants ─────────────────────────────────
+
+    @Test
+    void outcome_allowedWithDenialCode_throws() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new SemanticValidationOutcome(
+                        true, SemanticValidationReasonCode.UNKNOWN_CONTRACT, "msg", null, null));
+    }
+
+    @Test
+    void outcome_deniedWithAllowedCode_throws() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new SemanticValidationOutcome(
+                        false, SemanticValidationReasonCode.ALLOWED, "msg", null, null));
+    }
+
+    // ── All denial codes — representable ──────────────────────────────────────
+
+    @Test
+    void outcome_allDenialCodes_canBeRepresented() {
+        for (var code : SemanticValidationReasonCode.values()) {
+            if (code == SemanticValidationReasonCode.ALLOWED) continue;
+            var outcome = SemanticValidationOutcome.denied(code, "test message for " + code);
+            assertFalse(outcome.allowed());
+            assertEquals(code, outcome.reasonCode());
+        }
+    }
+
+    @Test
+    void outcome_entitlementDenial_representable() {
+        var o = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.DENIED_BY_ENTITLEMENT,
+                "You do not have access to cross-entity aggregation.",
+                "cib_var",
+                null);
+        assertFalse(o.allowed());
+        assertEquals(SemanticValidationReasonCode.DENIED_BY_ENTITLEMENT, o.reasonCode());
+        assertEquals("cib_var", o.contractId());
+        assertNull(o.invalidFields());
+    }
+
+    @Test
+    void outcome_invalidGroupingPath_representable() {
+        var o = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.INVALID_GROUPING_PATH,
+                "The grouping 'desk,legal_entity' is not a valid combination for cib_var.",
+                "cib_var",
+                List.of("desk", "legal_entity"));
+        assertFalse(o.allowed());
+        assertEquals(2, o.invalidFields().size());
+    }
+
+    @Test
+    void outcome_ambiguousRequest_representable() {
+        var o = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.AMBIGUOUS_REQUEST,
+                "The term 'risk' matches multiple dimensions. Please be more specific.");
+        assertFalse(o.allowed());
+        assertNull(o.contractId());
+    }
+}


### PR DESCRIPTION
## Summary

Adds the semantic request validation model in `org.iceforge.skadi.semantic.request` (`skadi-semantic`) — four types that give the buddy chat and future validation endpoint a structured, testable way to express whether a semantic operation is permitted.

Closes #78

## Types added

| Type | Kind | Purpose |
|---|---|---|
| `SemanticValidationReasonCode` | enum (12 values) | Machine-readable denial/allowed reasons |
| `SemanticValidationRequestType` | enum (6 values) | Kind of operation being validated |
| `SemanticValidationRequest` | record | Input: contractId + requestType + subjectId |
| `SemanticValidationOutcome` | record | Output: allowed flag + reason code + user message + optional context |

## Reason codes

**Allowed:** `ALLOWED`
**Not-found:** `UNKNOWN_CONTRACT`, `UNKNOWN_MEASURE`, `UNKNOWN_DIMENSION`
**Governance:** `DIMENSION_NOT_GROUPABLE`, `DIMENSION_NOT_FILTERABLE`, `INVALID_GROUPING_PATH`, `UNSUPPORTED_GRAIN`, `UNSUPPORTED_OUTPUT_SHAPE`
**Entitlement (placeholder):** `DENIED_BY_ENTITLEMENT`
**Request quality:** `AMBIGUOUS_REQUEST`, `UNSUPPORTED_REQUEST`

## Design

- `SemanticValidationOutcome` enforces the invariant: `allowed=true` ↔ `reasonCode=ALLOWED`
- Static factories `allowed(contractId, msg)` and `denied(code, msg[, contractId, invalidFields])`
- `invalidFields` is defensively copied when non-null
- No query execution, no SQL, no Databricks

## Test plan

- [x] 25 model tests: all reason codes, all request types, null/blank guards, allowed/denied factories, invariant enforcement, defensive copying, concrete scenarios (grouping denial, entitlement placeholder, ambiguous request, invalid grouping path)
- [x] All 465 `skadi-semantic` tests pass — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)