### PR TITLE
feat: add semantic request validation endpoint (E1.8)

### DIFF
--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationOutcome.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/request/SemanticValidationOutcome.java
@@ -1,5 +1,7 @@
 package org.iceforge.skadi.semantic.request;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -38,6 +40,7 @@ import java.util.Objects;
  *     "You do not have access to cross-entity aggregation for this contract.");
  * }</pre>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SemanticValidationOutcome(
         boolean allowed,
         SemanticValidationReasonCode reasonCode,

--- a/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticRequestValidationController.java
+++ b/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticRequestValidationController.java
@@ -1,0 +1,197 @@
+package org.iceforge.skadi.semantic;
+
+import org.iceforge.skadi.semantic.contract.SemanticContract;
+import org.iceforge.skadi.semantic.contract.SemanticContractExplanation;
+import org.iceforge.skadi.semantic.registry.ContractRegistry;
+import org.iceforge.skadi.semantic.request.SemanticValidationOutcome;
+import org.iceforge.skadi.semantic.request.SemanticValidationReasonCode;
+import org.iceforge.skadi.semantic.request.SemanticValidationRequest;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Validates semantic requests against active contract metadata (ADR-012).
+ *
+ * <h2>Endpoint</h2>
+ * <pre>POST /api/semantic/v1/query/validate</pre>
+ *
+ * <p>The caller provides a {@link SemanticValidationRequest} identifying the contract,
+ * the type of operation, and the subject (measure name, dimension name, grouping path,
+ * output shape, or grain). The response is a {@link SemanticValidationOutcome} with:
+ * <ul>
+ *   <li>{@code allowed} — {@code true} if the operation is permitted</li>
+ *   <li>{@code reasonCode} — machine-readable outcome code</li>
+ *   <li>{@code message} — user-safe explanation</li>
+ *   <li>{@code contractId} — which contract was checked (when available)</li>
+ *   <li>{@code invalidFields} — which fields caused denial (when applicable)</li>
+ * </ul>
+ *
+ * <p>This endpoint does not execute queries, generate SQL, call Databricks, or enforce
+ * entitlements beyond what the contract's explanation metadata declares.
+ */
+@RestController
+@RequestMapping("/api/semantic/v1/query")
+public class SemanticRequestValidationController {
+
+    private final ContractRegistry registry;
+
+    public SemanticRequestValidationController(ContractRegistry registry) {
+        this.registry = registry;
+    }
+
+    /**
+     * Validates a semantic request against the active contract registry.
+     *
+     * <p>Always returns HTTP 200 — the {@link SemanticValidationOutcome#allowed()} field
+     * carries the validation decision. This keeps the caller's control flow simple;
+     * HTTP error codes are reserved for malformed requests.
+     */
+    @PostMapping(value = "/validate",
+            consumes = "application/json",
+            produces = "application/json")
+    public SemanticValidationOutcome validate(@RequestBody SemanticValidationRequest request) {
+        var found = registry.findByName(request.contractId());
+        if (found.isEmpty()) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.UNKNOWN_CONTRACT,
+                    "Contract '" + request.contractId() + "' is not registered.");
+        }
+        return evaluate(found.get(), request);
+    }
+
+    // ── Validation logic ───────────────────────────────────────────────────────
+
+    private SemanticValidationOutcome evaluate(SemanticContract contract,
+                                               SemanticValidationRequest request) {
+        return switch (request.requestType()) {
+            case MEASURE_ACCESS     -> validateMeasureAccess(contract, request.subjectId());
+            case DIMENSION_GROUPING -> validateDimensionGrouping(contract, request.subjectId());
+            case DIMENSION_FILTER   -> validateDimensionFilter(contract, request.subjectId());
+            case GROUPING_PATH      -> validateGroupingPath(contract, request.subjectId());
+            case OUTPUT_SHAPE       -> validateOutputShape(contract, request.subjectId());
+            case GRAIN              -> validateGrain(contract, request.subjectId());
+        };
+    }
+
+    private SemanticValidationOutcome validateMeasureAccess(SemanticContract contract,
+                                                            String measureId) {
+        boolean exists = contract.measures().stream()
+                .anyMatch(m -> m.name().equals(measureId));
+        if (!exists) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.UNKNOWN_MEASURE,
+                    "Measure '" + measureId + "' is not defined in contract '" + contract.name() + "'.",
+                    contract.name(), List.of(measureId));
+        }
+        return SemanticValidationOutcome.allowed(
+                contract.name(),
+                "Measure '" + measureId + "' is defined and accessible in contract '" + contract.name() + "'.");
+    }
+
+    private SemanticValidationOutcome validateDimensionGrouping(SemanticContract contract,
+                                                                String dimensionId) {
+        var dim = contract.dimensions().stream()
+                .filter(d -> d.name().equals(dimensionId))
+                .findFirst();
+        if (dim.isEmpty()) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.UNKNOWN_DIMENSION,
+                    "Dimension '" + dimensionId + "' is not defined in contract '" + contract.name() + "'.",
+                    contract.name(), List.of(dimensionId));
+        }
+        if (!dim.get().groupable()) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.DIMENSION_NOT_GROUPABLE,
+                    "Dimension '" + dimensionId + "' is not available for grouping in contract '" + contract.name() + "'.",
+                    contract.name(), List.of(dimensionId));
+        }
+        return SemanticValidationOutcome.allowed(
+                contract.name(),
+                "Dimension '" + dimensionId + "' can be used for grouping in contract '" + contract.name() + "'.");
+    }
+
+    private SemanticValidationOutcome validateDimensionFilter(SemanticContract contract,
+                                                              String dimensionId) {
+        var dim = contract.dimensions().stream()
+                .filter(d -> d.name().equals(dimensionId))
+                .findFirst();
+        if (dim.isEmpty()) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.UNKNOWN_DIMENSION,
+                    "Dimension '" + dimensionId + "' is not defined in contract '" + contract.name() + "'.",
+                    contract.name(), List.of(dimensionId));
+        }
+        if (!dim.get().filterable()) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.DIMENSION_NOT_FILTERABLE,
+                    "Dimension '" + dimensionId + "' is not available as a filter in contract '" + contract.name() + "'.",
+                    contract.name(), List.of(dimensionId));
+        }
+        return SemanticValidationOutcome.allowed(
+                contract.name(),
+                "Dimension '" + dimensionId + "' can be used as a filter in contract '" + contract.name() + "'.");
+    }
+
+    private SemanticValidationOutcome validateGroupingPath(SemanticContract contract,
+                                                           String path) {
+        SemanticContractExplanation exp = contract.explanation();
+        if (exp == null || exp.validGroupingPaths() == null || exp.validGroupingPaths().isEmpty()) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.UNSUPPORTED_REQUEST,
+                    "Contract '" + contract.name() + "' does not declare valid grouping paths.",
+                    contract.name(), null);
+        }
+        if (!exp.validGroupingPaths().contains(path)) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.INVALID_GROUPING_PATH,
+                    "The grouping path '" + path + "' is not a declared valid grouping combination for contract '" + contract.name() + "'.",
+                    contract.name(), List.of(path));
+        }
+        return SemanticValidationOutcome.allowed(
+                contract.name(),
+                "The grouping path '" + path + "' is a valid grouping combination for contract '" + contract.name() + "'.");
+    }
+
+    private SemanticValidationOutcome validateOutputShape(SemanticContract contract,
+                                                          String shapeName) {
+        SemanticContractExplanation exp = contract.explanation();
+        if (exp == null || exp.outputShapes() == null || exp.outputShapes().isEmpty()) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.UNSUPPORTED_REQUEST,
+                    "Contract '" + contract.name() + "' does not declare output shapes.",
+                    contract.name(), null);
+        }
+        if (!exp.outputShapes().contains(shapeName)) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.UNSUPPORTED_OUTPUT_SHAPE,
+                    "Output shape '" + shapeName + "' is not declared for contract '" + contract.name() + "'.",
+                    contract.name(), List.of(shapeName));
+        }
+        return SemanticValidationOutcome.allowed(
+                contract.name(),
+                "Output shape '" + shapeName + "' is supported by contract '" + contract.name() + "'.");
+    }
+
+    private SemanticValidationOutcome validateGrain(SemanticContract contract, String grain) {
+        SemanticContractExplanation exp = contract.explanation();
+        if (exp == null || exp.grain() == null || exp.grain().isBlank()) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.UNSUPPORTED_REQUEST,
+                    "Contract '" + contract.name() + "' does not declare a grain.",
+                    contract.name(), null);
+        }
+        if (!exp.grain().equalsIgnoreCase(grain)) {
+            return SemanticValidationOutcome.denied(
+                    SemanticValidationReasonCode.UNSUPPORTED_GRAIN,
+                    "The stated grain does not match the declared grain for contract '" + contract.name() + "'.",
+                    contract.name(), null);
+        }
+        return SemanticValidationOutcome.allowed(
+                contract.name(),
+                "The stated grain matches the declared grain for contract '" + contract.name() + "'.");
+    }
+}

--- a/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticRequestValidationControllerTest.java
+++ b/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticRequestValidationControllerTest.java
@@ -1,0 +1,310 @@
+package org.iceforge.skadi.semantic;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.iceforge.skadi.semantic.contract.SemanticAccessPolicy;
+import org.iceforge.skadi.semantic.contract.SemanticCachePolicy;
+import org.iceforge.skadi.semantic.contract.SemanticContract;
+import org.iceforge.skadi.semantic.contract.SemanticContractExplanation;
+import org.iceforge.skadi.semantic.contract.SemanticContractVersion;
+import org.iceforge.skadi.semantic.contract.SemanticDimension;
+import org.iceforge.skadi.semantic.contract.SemanticEndpoint;
+import org.iceforge.skadi.semantic.contract.SemanticEntity;
+import org.iceforge.skadi.semantic.contract.SemanticEntitlementBehavior;
+import org.iceforge.skadi.semantic.contract.SemanticFieldType;
+import org.iceforge.skadi.semantic.contract.SemanticLineageHook;
+import org.iceforge.skadi.semantic.contract.SemanticMeasure;
+import org.iceforge.skadi.semantic.registry.ContractRegistry;
+import org.iceforge.skadi.semantic.request.SemanticValidationRequestType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Unit tests for {@link SemanticRequestValidationController}.
+ *
+ * <p>Uses MockMvc standalone — no Spring context, no Databricks, no SQL execution.
+ */
+class SemanticRequestValidationControllerTest {
+
+    private static final String URL = "/api/semantic/v1/query/validate";
+
+    private MockMvc mockMvc;
+    private ContractRegistry registry;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        registry = Mockito.mock(ContractRegistry.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new SemanticRequestValidationController(registry))
+                .build();
+        mapper = new ObjectMapper().disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private String body(String contractId, SemanticValidationRequestType type, String subjectId)
+            throws Exception {
+        return mapper.writeValueAsString(
+                new org.iceforge.skadi.semantic.request.SemanticValidationRequest(
+                        contractId, type, subjectId));
+    }
+
+    private static SemanticContract minimal(String name) {
+        var entity = new SemanticEntity(name, "", new SemanticEndpoint("c", "s", name), List.of());
+        return new SemanticContract(
+                name, new SemanticContractVersion("1.0.0"), "",
+                entity,
+                List.of(new SemanticMeasure("pnl", "PnL", "SUM(pnl)",
+                        SemanticFieldType.DECIMAL, "", null)),
+                List.of(
+                        new SemanticDimension("book", "book", SemanticFieldType.STRING,
+                                "Book", true, true, null),
+                        new SemanticDimension("desk", "desk", SemanticFieldType.STRING,
+                                "Desk", true, false, null)),
+                SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), null);
+    }
+
+    private static SemanticContract enriched(String name) {
+        var exp = new SemanticContractExplanation(
+                "Risk", "Daily VaR.", List.of("After 8 AM"),
+                "One row per legal entity and COB date",
+                List.of("var_by_entity", "var_by_risk_class"),
+                new SemanticLineageHook("H1", "lineage"),
+                new SemanticEntitlementBehavior("ROW_FILTER", "row filter"),
+                List.of("cob_date", "legal_entity", "cob_date,legal_entity"));
+        var entity = new SemanticEntity(name, "", new SemanticEndpoint("c", "s", name), List.of());
+        return new SemanticContract(
+                name, new SemanticContractVersion("2.0.0"), "", entity,
+                List.of(new SemanticMeasure("var_1d", "1-Day VaR", "SUM(v)",
+                        SemanticFieldType.DECIMAL, "", null)),
+                List.of(new SemanticDimension("legal_entity", "le_code",
+                        SemanticFieldType.STRING, "Legal Entity", true, true, null)),
+                SemanticAccessPolicy.unrestricted(), SemanticCachePolicy.none(), exp);
+    }
+
+    // ── Unknown contract ───────────────────────────────────────────────────────
+
+    @Test
+    void unknownContract_returnsAllowedFalse_withUnknownContractCode() throws Exception {
+        when(registry.findByName("ghost")).thenReturn(Optional.empty());
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("ghost", SemanticValidationRequestType.MEASURE_ACCESS, "pnl")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("UNKNOWN_CONTRACT"))
+                .andExpect(jsonPath("$.contractId").doesNotExist());
+    }
+
+    // ── MEASURE_ACCESS ─────────────────────────────────────────────────────────
+
+    @Test
+    void measureAccess_knownMeasure_returnsAllowed() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.MEASURE_ACCESS, "pnl")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(true))
+                .andExpect(jsonPath("$.reasonCode").value("ALLOWED"))
+                .andExpect(jsonPath("$.contractId").value("mxl_risk"));
+    }
+
+    @Test
+    void measureAccess_unknownMeasure_returnsDenied() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.MEASURE_ACCESS, "nonexistent")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("UNKNOWN_MEASURE"))
+                .andExpect(jsonPath("$.contractId").value("mxl_risk"))
+                .andExpect(jsonPath("$.invalidFields[0]").value("nonexistent"));
+    }
+
+    // ── DIMENSION_GROUPING ─────────────────────────────────────────────────────
+
+    @Test
+    void dimensionGrouping_groupableDimension_returnsAllowed() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.DIMENSION_GROUPING, "book")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(true))
+                .andExpect(jsonPath("$.reasonCode").value("ALLOWED"));
+    }
+
+    @Test
+    void dimensionGrouping_nonGroupableDimension_returnsDenied() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.DIMENSION_GROUPING, "desk")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("DIMENSION_NOT_GROUPABLE"))
+                .andExpect(jsonPath("$.invalidFields[0]").value("desk"));
+    }
+
+    @Test
+    void dimensionGrouping_unknownDimension_returnsDenied() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.DIMENSION_GROUPING, "ghost")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("UNKNOWN_DIMENSION"))
+                .andExpect(jsonPath("$.invalidFields[0]").value("ghost"));
+    }
+
+    // ── DIMENSION_FILTER ───────────────────────────────────────────────────────
+
+    @Test
+    void dimensionFilter_filterableDimension_returnsAllowed() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.DIMENSION_FILTER, "desk")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(true))
+                .andExpect(jsonPath("$.reasonCode").value("ALLOWED"));
+    }
+
+    @Test
+    void dimensionFilter_unknownDimension_returnsDenied() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.DIMENSION_FILTER, "ghost")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("UNKNOWN_DIMENSION"));
+    }
+
+    // ── GROUPING_PATH ──────────────────────────────────────────────────────────
+
+    @Test
+    void groupingPath_validPath_returnsAllowed() throws Exception {
+        when(registry.findByName("cib_var")).thenReturn(Optional.of(enriched("cib_var")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("cib_var", SemanticValidationRequestType.GROUPING_PATH, "cob_date,legal_entity")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(true))
+                .andExpect(jsonPath("$.reasonCode").value("ALLOWED"));
+    }
+
+    @Test
+    void groupingPath_invalidPath_returnsDenied() throws Exception {
+        when(registry.findByName("cib_var")).thenReturn(Optional.of(enriched("cib_var")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("cib_var", SemanticValidationRequestType.GROUPING_PATH, "desk,legal_entity")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("INVALID_GROUPING_PATH"))
+                .andExpect(jsonPath("$.invalidFields[0]").value("desk,legal_entity"));
+    }
+
+    @Test
+    void groupingPath_noPathsDeclared_returnsUnsupportedRequest() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.GROUPING_PATH, "book")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("UNSUPPORTED_REQUEST"));
+    }
+
+    // ── OUTPUT_SHAPE ───────────────────────────────────────────────────────────
+
+    @Test
+    void outputShape_supportedShape_returnsAllowed() throws Exception {
+        when(registry.findByName("cib_var")).thenReturn(Optional.of(enriched("cib_var")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("cib_var", SemanticValidationRequestType.OUTPUT_SHAPE, "var_by_entity")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(true))
+                .andExpect(jsonPath("$.reasonCode").value("ALLOWED"));
+    }
+
+    @Test
+    void outputShape_unsupportedShape_returnsDenied() throws Exception {
+        when(registry.findByName("cib_var")).thenReturn(Optional.of(enriched("cib_var")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("cib_var", SemanticValidationRequestType.OUTPUT_SHAPE, "var_by_desk")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("UNSUPPORTED_OUTPUT_SHAPE"))
+                .andExpect(jsonPath("$.invalidFields[0]").value("var_by_desk"));
+    }
+
+    @Test
+    void outputShape_noShapesDeclared_returnsUnsupportedRequest() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.OUTPUT_SHAPE, "pnl_view")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("UNSUPPORTED_REQUEST"));
+    }
+
+    // ── GRAIN ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void grain_matchingGrain_returnsAllowed() throws Exception {
+        when(registry.findByName("cib_var")).thenReturn(Optional.of(enriched("cib_var")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("cib_var", SemanticValidationRequestType.GRAIN,
+                                "One row per legal entity and COB date")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(true))
+                .andExpect(jsonPath("$.reasonCode").value("ALLOWED"));
+    }
+
+    @Test
+    void grain_mismatchedGrain_returnsDenied() throws Exception {
+        when(registry.findByName("cib_var")).thenReturn(Optional.of(enriched("cib_var")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("cib_var", SemanticValidationRequestType.GRAIN, "daily aggregate")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("UNSUPPORTED_GRAIN"));
+    }
+
+    @Test
+    void grain_noGrainDeclared_returnsUnsupportedRequest() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.GRAIN, "daily")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allowed").value(false))
+                .andExpect(jsonPath("$.reasonCode").value("UNSUPPORTED_REQUEST"));
+    }
+
+    // ── JSON response shape ────────────────────────────────────────────────────
+
+    @Test
+    void allowedOutcome_nullFieldsOmittedFromResponse() throws Exception {
+        when(registry.findByName("mxl_risk")).thenReturn(Optional.of(minimal("mxl_risk")));
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("mxl_risk", SemanticValidationRequestType.MEASURE_ACCESS, "pnl")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.invalidFields").doesNotExist());
+    }
+
+    @Test
+    void deniedOutcome_unknownContract_noContractIdInResponse() throws Exception {
+        when(registry.findByName("x")).thenReturn(Optional.empty());
+        mockMvc.perform(post(URL).contentType(MediaType.APPLICATION_JSON)
+                        .content(body("x", SemanticValidationRequestType.MEASURE_ACCESS, "m")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.contractId").doesNotExist())
+                .andExpect(jsonPath("$.invalidFields").doesNotExist());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `POST /api/semantic/v1/query/validate` — the ADR-012 semantic request validation endpoint. Always returns HTTP 200; the `allowed` field in the JSON response carries the decision. Uses E1.7 model types throughout.

Also adds `@JsonInclude(NON_NULL)` to `SemanticValidationOutcome` so null `contractId` and `invalidFields` are omitted from responses.

Closes #79

## Validation logic

| Request type | Allowed when | Denied with |
|---|---|---|
| `MEASURE_ACCESS` | Measure exists in contract | `UNKNOWN_MEASURE` |
| `DIMENSION_GROUPING` | Dimension exists AND `groupable=true` | `UNKNOWN_DIMENSION` / `DIMENSION_NOT_GROUPABLE` |
| `DIMENSION_FILTER` | Dimension exists AND `filterable=true` | `UNKNOWN_DIMENSION` / `DIMENSION_NOT_FILTERABLE` |
| `GROUPING_PATH` | Path in `validGroupingPaths` list | `INVALID_GROUPING_PATH` / `UNSUPPORTED_REQUEST` (no paths declared) |
| `OUTPUT_SHAPE` | Shape in `outputShapes` list | `UNSUPPORTED_OUTPUT_SHAPE` / `UNSUPPORTED_REQUEST` (no shapes declared) |
| `GRAIN` | Grain matches declared grain (case-insensitive) | `UNSUPPORTED_GRAIN` / `UNSUPPORTED_REQUEST` (no grain declared) |
| Any | Contract not in registry | `UNKNOWN_CONTRACT` |

## Test plan

- [x] 19 MockMvc tests: unknown contract, all 6 request types (allowed + denied cases), null-field omission in response
- [x] All 465 `skadi-semantic` tests pass — 0 failures
- [x] All 181 `skadi-server` tests pass — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)