### PR TITLE
feat: add screen context semantic binding model (E1.9)

### DIFF
--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/ActiveWidgetContext.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/ActiveWidgetContext.java
@@ -1,0 +1,32 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+/**
+ * Identifies the widget currently focused or active on the dashboard screen.
+ *
+ * <p>The buddy chat uses this to determine which widget the user is asking about
+ * when they ask "What is this chart showing?" without naming a specific widget.
+ *
+ * <p>The {@link #widgetType()} describes the visualisation type (e.g.
+ * {@code "bar_chart"}, {@code "line_chart"}, {@code "table"}, {@code "metric_card"})
+ * and helps the buddy chat tailor its explanation to the visual form.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ActiveWidgetContext(
+        String widgetId,
+        String widgetType) {
+
+    /**
+     * @param widgetId   stable widget identifier matching {@link WidgetSemanticBinding#widgetId()}; must not be null or blank
+     * @param widgetType visualisation type string; must not be null or blank
+     */
+    public ActiveWidgetContext {
+        Objects.requireNonNull(widgetId,   "widgetId must not be null");
+        Objects.requireNonNull(widgetType, "widgetType must not be null");
+        if (widgetId.isBlank())   throw new IllegalArgumentException("widgetId must not be blank");
+        if (widgetType.isBlank()) throw new IllegalArgumentException("widgetType must not be blank");
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/AppliedFilter.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/AppliedFilter.java
@@ -1,0 +1,35 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+/**
+ * A filter currently constraining the widget's data.
+ *
+ * <p>The {@link #dimensionId()} must match a dimension with {@code filterable=true}
+ * in the governing contract. The {@link #operator()} and {@link #value()} describe
+ * the predicate applied (e.g. {@code "equals"}, {@code "gte"}, {@code "in"}).
+ *
+ * <p>Values are represented as strings for serialization; the semantic layer
+ * interprets them according to the dimension's declared type.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AppliedFilter(
+        String dimensionId,
+        String operator,
+        String value) {
+
+    /**
+     * @param dimensionId the filterable dimension name; must not be null or blank
+     * @param operator    the filter operator (e.g. {@code "equals"}, {@code "gte"}); must not be null or blank
+     * @param value       the filter value as a string; must not be null
+     */
+    public AppliedFilter {
+        Objects.requireNonNull(dimensionId, "dimensionId must not be null");
+        Objects.requireNonNull(operator,    "operator must not be null");
+        Objects.requireNonNull(value,       "value must not be null");
+        if (dimensionId.isBlank()) throw new IllegalArgumentException("dimensionId must not be blank");
+        if (operator.isBlank())    throw new IllegalArgumentException("operator must not be blank");
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/BoundDimension.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/BoundDimension.java
@@ -1,0 +1,27 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+/**
+ * A dimension used for grouping or breakdown in a widget.
+ *
+ * <p>The {@link #dimensionId()} must match a dimension name defined in the widget's
+ * governing semantic contract and must have {@code groupable=true} in that contract.
+ * The optional {@link #label()} is the display label rendered on the axis or in legends.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BoundDimension(
+        String dimensionId,
+        String label) {
+
+    /**
+     * @param dimensionId the dimension name as defined in the semantic contract; must not be null or blank
+     * @param label       optional display label for the dimension; may be null
+     */
+    public BoundDimension {
+        Objects.requireNonNull(dimensionId, "dimensionId must not be null");
+        if (dimensionId.isBlank()) throw new IllegalArgumentException("dimensionId must not be blank");
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/BoundMeasure.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/BoundMeasure.java
@@ -1,0 +1,27 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+/**
+ * A measure currently selected and displayed within a widget.
+ *
+ * <p>The {@link #measureId()} must match a measure name defined in the widget's
+ * governing semantic contract. The optional {@link #label()} is the display label
+ * rendered in the widget's legend or axis.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BoundMeasure(
+        String measureId,
+        String label) {
+
+    /**
+     * @param measureId the measure name as defined in the semantic contract; must not be null or blank
+     * @param label     optional display label for the measure; may be null
+     */
+    public BoundMeasure {
+        Objects.requireNonNull(measureId, "measureId must not be null");
+        if (measureId.isBlank()) throw new IllegalArgumentException("measureId must not be blank");
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/ContractBinding.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/ContractBinding.java
@@ -1,0 +1,29 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+/**
+ * Identifies which semantic contract and version powers a widget.
+ *
+ * <p>The {@link #contractId()} is the lookup key in the {@code ContractRegistry}.
+ * The {@link #contractVersion()} records which contract version was active when
+ * the widget was rendered, enabling the buddy chat to detect stale bindings.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ContractBinding(
+        String contractId,
+        String contractVersion) {
+
+    /**
+     * @param contractId      name of the semantic contract; must not be null or blank
+     * @param contractVersion semver string of the contract in use; must not be null or blank
+     */
+    public ContractBinding {
+        Objects.requireNonNull(contractId,      "contractId must not be null");
+        Objects.requireNonNull(contractVersion, "contractVersion must not be null");
+        if (contractId.isBlank())      throw new IllegalArgumentException("contractId must not be blank");
+        if (contractVersion.isBlank()) throw new IllegalArgumentException("contractVersion must not be blank");
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/DashboardScreenContext.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/DashboardScreenContext.java
@@ -1,0 +1,49 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The complete semantic context of the dashboard screen at the moment the user
+ * sends a buddy-chat question.
+ *
+ * <p>The buddy chat uses this object to answer screen-aware questions like
+ * "What is this chart showing?" by correlating {@link #activeWidget()} with the
+ * matching entry in {@link #widgetBindings()} and interrogating the governing
+ * semantic contract.
+ *
+ * <p>{@link #dashboardId()} identifies which dashboard is open (nullable — the
+ * dashboard identity may not be available in all contexts). {@link #activeWidget()}
+ * is nullable when no widget has focus. {@link #widgetBindings()} is never null
+ * but may be empty when no semantic widgets are on screen.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DashboardScreenContext(
+        String dashboardId,
+        ActiveWidgetContext activeWidget,
+        List<WidgetSemanticBinding> widgetBindings) {
+
+    /**
+     * @param dashboardId    identifier of the open dashboard; may be null
+     * @param activeWidget   the currently focused widget; may be null
+     * @param widgetBindings semantic bindings for all widgets on the screen;
+     *                       must not be null; defensively copied
+     */
+    public DashboardScreenContext {
+        Objects.requireNonNull(widgetBindings, "widgetBindings must not be null");
+        widgetBindings = List.copyOf(widgetBindings);
+    }
+
+    /**
+     * Returns the binding for the active widget, if one is active and its binding is present.
+     */
+    public Optional<WidgetSemanticBinding> activeWidgetBinding() {
+        if (activeWidget == null) return Optional.empty();
+        return widgetBindings.stream()
+                .filter(b -> b.widgetId().equals(activeWidget.widgetId()))
+                .findFirst();
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/ExplainWidgetBindingRequest.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/ExplainWidgetBindingRequest.java
@@ -1,0 +1,41 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+/**
+ * A request for the buddy chat to explain what a specific widget is showing.
+ *
+ * <p>This is the primary input type for ADR-012 screen-context-aware explanations.
+ * The caller provides the target widget ID and the full dashboard screen context;
+ * the buddy chat resolves the widget's semantic binding and interrogates the
+ * governing contract to produce a governed explanation.
+ *
+ * <p>This record defines the input contract only — buddy-chat runtime and LLM
+ * integration are out of scope for Lane E1.
+ *
+ * <pre>{@code
+ * var request = new ExplainWidgetBindingRequest(
+ *     "widget-pnl-by-book",
+ *     new DashboardScreenContext(
+ *         "dashboard-risk-overview",
+ *         new ActiveWidgetContext("widget-pnl-by-book", "bar_chart"),
+ *         List.of(binding)));
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ExplainWidgetBindingRequest(
+        String widgetId,
+        DashboardScreenContext screenContext) {
+
+    /**
+     * @param widgetId      the ID of the widget to explain; must not be null or blank
+     * @param screenContext the full dashboard screen context; must not be null
+     */
+    public ExplainWidgetBindingRequest {
+        Objects.requireNonNull(widgetId,      "widgetId must not be null");
+        Objects.requireNonNull(screenContext, "screenContext must not be null");
+        if (widgetId.isBlank()) throw new IllegalArgumentException("widgetId must not be blank");
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/UserEntitlementScope.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/UserEntitlementScope.java
@@ -1,0 +1,32 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+/**
+ * Placeholder representing the entitlement scope of the user viewing a widget.
+ *
+ * <p>This type is a seam for future entitlement enforcement. The buddy chat uses it
+ * to contextualise explanation responses — e.g. "You can only see data for legal
+ * entities in your entitlement set." Enforcement logic is deferred to a future lane.
+ *
+ * <p>All fields are required to ensure the buddy chat always has a principal identity.
+ * The {@link #entitlementSetId()} is nullable when the user has no scoped entitlement
+ * (i.e. full access under the contract's access policy).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record UserEntitlementScope(
+        String principalId,
+        String entitlementSetId) {
+
+    /**
+     * @param principalId      the identity of the requesting user; must not be null or blank
+     * @param entitlementSetId the entitlement group/set ID scoping this user's data access;
+     *                         may be null when the user has unrestricted access
+     */
+    public UserEntitlementScope {
+        Objects.requireNonNull(principalId, "principalId must not be null");
+        if (principalId.isBlank()) throw new IllegalArgumentException("principalId must not be blank");
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/WidgetSemanticBinding.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/screen/WidgetSemanticBinding.java
@@ -1,0 +1,47 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The complete semantic binding for one widget — which contract, measures,
+ * dimensions, and filters are currently active.
+ *
+ * <p>The buddy chat uses this binding to answer "What is this chart showing?"
+ * by interrogating the governing semantic contract for the bound measures and
+ * dimensions, and describing the applied filters in business terms.
+ *
+ * <p>{@link #filters()} and {@link #userEntitlementScope()} are optional; a widget
+ * with no active filters or no scoped entitlement passes empty list / null respectively.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record WidgetSemanticBinding(
+        String widgetId,
+        ContractBinding contractBinding,
+        List<BoundMeasure> measures,
+        List<BoundDimension> dimensions,
+        List<AppliedFilter> filters,
+        UserEntitlementScope userEntitlementScope) {
+
+    /**
+     * @param widgetId              stable widget identifier matching {@link ActiveWidgetContext#widgetId()}; must not be null or blank
+     * @param contractBinding       the contract and version powering this widget; must not be null
+     * @param measures              measures displayed in this widget; must not be null; defensively copied
+     * @param dimensions            dimensions used for grouping; must not be null; defensively copied
+     * @param filters               active filter predicates; must not be null; defensively copied
+     * @param userEntitlementScope  entitlement scope of the viewing user; may be null
+     */
+    public WidgetSemanticBinding {
+        Objects.requireNonNull(widgetId,         "widgetId must not be null");
+        Objects.requireNonNull(contractBinding,  "contractBinding must not be null");
+        Objects.requireNonNull(measures,         "measures must not be null");
+        Objects.requireNonNull(dimensions,       "dimensions must not be null");
+        Objects.requireNonNull(filters,          "filters must not be null");
+        if (widgetId.isBlank()) throw new IllegalArgumentException("widgetId must not be blank");
+        measures   = List.copyOf(measures);
+        dimensions = List.copyOf(dimensions);
+        filters    = List.copyOf(filters);
+    }
+}

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/screen/ScreenContextModelTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/screen/ScreenContextModelTest.java
@@ -1,0 +1,325 @@
+package org.iceforge.skadi.semantic.screen;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the screen-context and widget semantic binding model types.
+ *
+ * <p>No Spring context, no SQL, no external services.
+ */
+class ScreenContextModelTest {
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static ContractBinding binding() {
+        return new ContractBinding("cib_var", "2.0.0");
+    }
+
+    private static WidgetSemanticBinding widgetBinding(String widgetId) {
+        return new WidgetSemanticBinding(
+                widgetId,
+                binding(),
+                List.of(new BoundMeasure("var_1d", "1-Day VaR")),
+                List.of(new BoundDimension("legal_entity", "Legal Entity")),
+                List.of(new AppliedFilter("cob_date", "equals", "2026-05-17")),
+                new UserEntitlementScope("alice", "cib-risk-team"));
+    }
+
+    // ── ContractBinding ────────────────────────────────────────────────────────
+
+    @Test
+    void contractBinding_holdsFields() {
+        var b = new ContractBinding("cib_var", "2.0.0");
+        assertEquals("cib_var", b.contractId());
+        assertEquals("2.0.0", b.contractVersion());
+    }
+
+    @Test
+    void contractBinding_rejectsNullContractId() {
+        assertThrows(NullPointerException.class, () -> new ContractBinding(null, "1.0.0"));
+    }
+
+    @Test
+    void contractBinding_rejectsBlankVersion() {
+        assertThrows(IllegalArgumentException.class, () -> new ContractBinding("c", "  "));
+    }
+
+    // ── BoundMeasure ──────────────────────────────────────────────────────────
+
+    @Test
+    void boundMeasure_holdsFields() {
+        var m = new BoundMeasure("var_1d", "1-Day VaR");
+        assertEquals("var_1d", m.measureId());
+        assertEquals("1-Day VaR", m.label());
+    }
+
+    @Test
+    void boundMeasure_nullLabelAllowed() {
+        assertDoesNotThrow(() -> new BoundMeasure("pnl", null));
+    }
+
+    @Test
+    void boundMeasure_rejectsBlankMeasureId() {
+        assertThrows(IllegalArgumentException.class, () -> new BoundMeasure("", "label"));
+    }
+
+    // ── BoundDimension ────────────────────────────────────────────────────────
+
+    @Test
+    void boundDimension_holdsFields() {
+        var d = new BoundDimension("legal_entity", "Legal Entity");
+        assertEquals("legal_entity", d.dimensionId());
+        assertEquals("Legal Entity", d.label());
+    }
+
+    @Test
+    void boundDimension_nullLabelAllowed() {
+        assertDoesNotThrow(() -> new BoundDimension("book", null));
+    }
+
+    @Test
+    void boundDimension_rejectsNullDimensionId() {
+        assertThrows(NullPointerException.class, () -> new BoundDimension(null, "label"));
+    }
+
+    // ── AppliedFilter ─────────────────────────────────────────────────────────
+
+    @Test
+    void appliedFilter_holdsFields() {
+        var f = new AppliedFilter("cob_date", "equals", "2026-05-17");
+        assertEquals("cob_date", f.dimensionId());
+        assertEquals("equals", f.operator());
+        assertEquals("2026-05-17", f.value());
+    }
+
+    @Test
+    void appliedFilter_rejectsNullOperator() {
+        assertThrows(NullPointerException.class,
+                () -> new AppliedFilter("d", null, "v"));
+    }
+
+    @Test
+    void appliedFilter_rejectsBlankDimensionId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new AppliedFilter("  ", "gte", "v"));
+    }
+
+    // ── UserEntitlementScope ──────────────────────────────────────────────────
+
+    @Test
+    void entitlementScope_holdsFields() {
+        var s = new UserEntitlementScope("alice", "cib-risk-team");
+        assertEquals("alice", s.principalId());
+        assertEquals("cib-risk-team", s.entitlementSetId());
+    }
+
+    @Test
+    void entitlementScope_nullEntitlementSetIdAllowed() {
+        var s = new UserEntitlementScope("alice", null);
+        assertNull(s.entitlementSetId());
+    }
+
+    @Test
+    void entitlementScope_rejectsBlankPrincipalId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new UserEntitlementScope("  ", null));
+    }
+
+    // ── ActiveWidgetContext ────────────────────────────────────────────────────
+
+    @Test
+    void activeWidgetContext_holdsFields() {
+        var a = new ActiveWidgetContext("widget-pnl", "bar_chart");
+        assertEquals("widget-pnl", a.widgetId());
+        assertEquals("bar_chart", a.widgetType());
+    }
+
+    @Test
+    void activeWidgetContext_rejectsBlankWidgetType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveWidgetContext("w", ""));
+    }
+
+    // ── WidgetSemanticBinding ─────────────────────────────────────────────────
+
+    @Test
+    void widgetBinding_holdsAllFields() {
+        var wb = widgetBinding("widget-pnl");
+        assertEquals("widget-pnl", wb.widgetId());
+        assertEquals("cib_var", wb.contractBinding().contractId());
+        assertEquals(1, wb.measures().size());
+        assertEquals("var_1d", wb.measures().get(0).measureId());
+        assertEquals(1, wb.dimensions().size());
+        assertEquals(1, wb.filters().size());
+        assertNotNull(wb.userEntitlementScope());
+        assertEquals("alice", wb.userEntitlementScope().principalId());
+    }
+
+    @Test
+    void widgetBinding_nullEntitlementScopeAllowed() {
+        var wb = new WidgetSemanticBinding(
+                "w", binding(),
+                List.of(new BoundMeasure("m", null)),
+                List.of(),
+                List.of(),
+                null);
+        assertNull(wb.userEntitlementScope());
+    }
+
+    @Test
+    void widgetBinding_measures_defensivelyCopied() {
+        var mutable = new ArrayList<BoundMeasure>();
+        mutable.add(new BoundMeasure("m1", null));
+        var wb = new WidgetSemanticBinding("w", binding(), mutable, List.of(), List.of(), null);
+        mutable.add(new BoundMeasure("m2", null));
+        assertEquals(1, wb.measures().size());
+    }
+
+    @Test
+    void widgetBinding_filters_unmodifiable() {
+        var wb = widgetBinding("w");
+        assertThrows(UnsupportedOperationException.class,
+                () -> wb.filters().add(new AppliedFilter("d", "eq", "v")));
+    }
+
+    @Test
+    void widgetBinding_rejectsNullContractBinding() {
+        assertThrows(NullPointerException.class,
+                () -> new WidgetSemanticBinding("w", null, List.of(), List.of(), List.of(), null));
+    }
+
+    // ── DashboardScreenContext ────────────────────────────────────────────────
+
+    @Test
+    void screenContext_holdsFields() {
+        var ctx = new DashboardScreenContext(
+                "dash-risk",
+                new ActiveWidgetContext("widget-pnl", "bar_chart"),
+                List.of(widgetBinding("widget-pnl")));
+        assertEquals("dash-risk", ctx.dashboardId());
+        assertNotNull(ctx.activeWidget());
+        assertEquals(1, ctx.widgetBindings().size());
+    }
+
+    @Test
+    void screenContext_nullDashboardIdAllowed() {
+        var ctx = new DashboardScreenContext(null, null, List.of());
+        assertNull(ctx.dashboardId());
+        assertNull(ctx.activeWidget());
+        assertTrue(ctx.widgetBindings().isEmpty());
+    }
+
+    @Test
+    void screenContext_widgetBindings_defensivelyCopied() {
+        var mutable = new ArrayList<WidgetSemanticBinding>();
+        mutable.add(widgetBinding("w1"));
+        var ctx = new DashboardScreenContext(null, null, mutable);
+        mutable.add(widgetBinding("w2"));
+        assertEquals(1, ctx.widgetBindings().size());
+    }
+
+    @Test
+    void screenContext_activeWidgetBinding_foundWhenPresent() {
+        var wb = widgetBinding("widget-pnl");
+        var ctx = new DashboardScreenContext(
+                "dash",
+                new ActiveWidgetContext("widget-pnl", "bar_chart"),
+                List.of(wb));
+        var found = ctx.activeWidgetBinding();
+        assertTrue(found.isPresent());
+        assertEquals("widget-pnl", found.get().widgetId());
+    }
+
+    @Test
+    void screenContext_activeWidgetBinding_emptyWhenNoActiveWidget() {
+        var ctx = new DashboardScreenContext(null, null, List.of(widgetBinding("w")));
+        assertTrue(ctx.activeWidgetBinding().isEmpty());
+    }
+
+    @Test
+    void screenContext_activeWidgetBinding_emptyWhenNoMatchingBinding() {
+        var ctx = new DashboardScreenContext(
+                null,
+                new ActiveWidgetContext("widget-other", "table"),
+                List.of(widgetBinding("widget-pnl")));
+        assertTrue(ctx.activeWidgetBinding().isEmpty());
+    }
+
+    // ── ExplainWidgetBindingRequest ───────────────────────────────────────────
+
+    @Test
+    void explainRequest_holdsFields() {
+        var ctx = new DashboardScreenContext(null, null, List.of());
+        var req = new ExplainWidgetBindingRequest("widget-pnl", ctx);
+        assertEquals("widget-pnl", req.widgetId());
+        assertSame(ctx, req.screenContext());
+    }
+
+    @Test
+    void explainRequest_rejectsNullScreenContext() {
+        assertThrows(NullPointerException.class,
+                () -> new ExplainWidgetBindingRequest("w", null));
+    }
+
+    @Test
+    void explainRequest_rejectsBlankWidgetId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExplainWidgetBindingRequest("", new DashboardScreenContext(null, null, List.of())));
+    }
+
+    // ── JSON serialization ────────────────────────────────────────────────────
+
+    @Test
+    void widgetBinding_nullEntitlementScope_omittedFromJson() throws Exception {
+        var mapper = new ObjectMapper().disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+        var wb = new WidgetSemanticBinding(
+                "w", binding(),
+                List.of(new BoundMeasure("m", null)),
+                List.of(), List.of(), null);
+        var json = mapper.writeValueAsString(wb);
+        assertFalse(json.contains("userEntitlementScope"), "null scope must be omitted");
+        assertTrue(json.contains("cib_var"));
+    }
+
+    @Test
+    void boundMeasure_nullLabel_omittedFromJson() throws Exception {
+        var mapper = new ObjectMapper().disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+        var json = mapper.writeValueAsString(new BoundMeasure("pnl", null));
+        assertFalse(json.contains("label"), "null label must be omitted");
+        assertTrue(json.contains("pnl"));
+    }
+
+    @Test
+    void screenContext_nullDashboardId_omittedFromJson() throws Exception {
+        var mapper = new ObjectMapper().disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+        var ctx = new DashboardScreenContext(null, null, List.of());
+        var json = mapper.writeValueAsString(ctx);
+        assertFalse(json.contains("dashboardId"), "null dashboardId must be omitted");
+        assertFalse(json.contains("activeWidget"), "null activeWidget must be omitted");
+    }
+
+    @Test
+    void fullRequest_roundTripJson() throws Exception {
+        var mapper = new ObjectMapper().disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+        var wb = widgetBinding("widget-pnl");
+        var ctx = new DashboardScreenContext(
+                "dash-risk",
+                new ActiveWidgetContext("widget-pnl", "bar_chart"),
+                List.of(wb));
+        var req = new ExplainWidgetBindingRequest("widget-pnl", ctx);
+        var json = mapper.writeValueAsString(req);
+        var restored = mapper.readValue(json, ExplainWidgetBindingRequest.class);
+        assertEquals(req.widgetId(), restored.widgetId());
+        assertEquals(req.screenContext().dashboardId(), restored.screenContext().dashboardId());
+        assertEquals(1, restored.screenContext().widgetBindings().size());
+        assertEquals("var_1d", restored.screenContext().widgetBindings()
+                .get(0).measures().get(0).measureId());
+    }
+}


### PR DESCRIPTION
## Summary

Adds nine model types in `org.iceforge.skadi.semantic.screen` (`skadi-semantic`) for ADR-012 screen-context-aware buddy-chat explanations. Aligned with ADR-006 dashboard brick concepts. All types are framework-independent, `@JsonInclude(NON_NULL)`, and Jackson-serializable.

Closes #80

## Types added

| Type | Purpose |
|---|---|
| `ContractBinding` | contractId + version powering a widget |
| `BoundMeasure` | Measure selected in the widget (with optional display label) |
| `BoundDimension` | Dimension used for grouping (with optional display label) |
| `AppliedFilter` | Active filter predicate (dimensionId, operator, value) |
| `UserEntitlementScope` | principalId + optional entitlementSetId (placeholder seam) |
| `WidgetSemanticBinding` | Full binding: contract, measures, dimensions, filters, entitlement; lists defensively copied |
| `ActiveWidgetContext` | Which widget is currently focused (widgetId, widgetType) |
| `DashboardScreenContext` | Full screen state with `activeWidgetBinding()` resolver helper |
| `ExplainWidgetBindingRequest` | Input type for "What is this chart showing?" |

## Test plan

- [x] 35 model tests: construction, null/blank guards, defensive copying, unmodifiable lists, `activeWidgetBinding()` resolution (found, no active widget, no matching binding), null-field JSON omission, full round-trip JSON
- [x] All `skadi-semantic` tests pass — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)