### PR TITLE
Normalize repository line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,48 @@
-/mvnw text eol=lf
-*.cmd text eol=crlf
+# Default: auto-detect text files and normalize to LF on check-in
+* text=auto eol=lf
+
+# --- Source ---
+*.java       text eol=lf
+*.xml        text eol=lf
+*.yml        text eol=lf
+*.yaml       text eol=lf
+*.json       text eol=lf
+*.md         text eol=lf
+*.sh         text eol=lf
+*.properties text eol=lf
+*.html       text eol=lf
+*.css        text eol=lf
+*.tsx        text eol=lf
+*.ts         text eol=lf
+*.sql        text eol=lf
+*.txt        text eol=lf
+
+# --- Config / meta ---
+.gitignore     text eol=lf
+.gitattributes text eol=lf
+Makefile       text eol=lf
+Dockerfile     text eol=lf
+LICENSE        text eol=lf
+/mvnw          text eol=lf
+*.config       text eol=lf
+
+# --- Windows scripts — keep CRLF ---
+*.cmd  text eol=crlf
+*.bat  text eol=crlf
+*.ps1  text eol=crlf
+
+# --- Binary — no line-ending conversion ---
+*.jar      binary
+*.class    binary
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.ico      binary
+*.zip      binary
+*.tar      binary
+*.gz       binary
+*.p12      binary
+*.jks      binary
+*.keystore binary
+deps.lock  binary


### PR DESCRIPTION
Add comprehensive .gitattributes rules so text files always normalize to LF on check-in, regardless of OS or git client:

- `* text=auto eol=lf` catch-all for all auto-detected text files
- Explicit eol=lf for every tracked text type: .java .xml .yml .yaml .json .md .sh .properties .html .css .tsx .ts .sql .txt, plus Makefile, Dockerfile, LICENSE, .gitignore, .gitattributes, .config
- `*.cmd / *.bat / *.ps1` explicitly eol=crlf (Windows scripts)
- Binary markers: common archive/image/keystore types + deps.lock (UTF-16 LE file; must not undergo line-ending conversion)

Ran `git add --renormalize .` to flush the index against the new rules; all 179 previously-noisy CRLF working-tree diffs are gone. Build verified: 232 tests, 0 failures.