### PR TITLE
docs: Lane E status update and DQR cleanup after skadi#97

### DIFF
--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -1,9 +1,9 @@
 # Skadi — Development Status
 
 > Updated: 2026-05-17
-> Branch: `main`
-> Last commit: `2f53fa4` — docs: add buddy chat semantic model interrogation decision (ADR-012)
-> Build: ✅ 494 tests passing (`mvn verify -pl skadi-semantic,skadi-server -am`; gateway test counts unchanged)
+> Branch: `feature/97-lane-e-semantic-execution-activation`
+> Last commit: `42e4a4a` — Lane E semantic execution activation — skadi#97
+> Build: ✅ 710 tests passing (`mvn verify -pl skadi-semantic,skadi-server -am`; gateway test counts unchanged)
 
 ---
 
@@ -326,7 +326,56 @@ All D-lane issues closed. Committed directly to `main`.
 
 ---
 
-## Architecture Evolution (Lane C+/D+)
+## Lane E — Semantic Execution Activation (In Progress)
+
+| Story | Description | Status | Commit | Issue |
+|---|---|---|---|---|
+| E1 | Semantic execution activation (`SkadiServerQueryExecutionService`) | ✅ | `42e4a4a` | #97 |
+
+---
+
+## Lane E Completed — E1 Summary
+
+**Issue:** #97 | **PR:** #102 | **Commit:** `42e4a4a`
+
+**Lane E E1 scope:** Activate the semantic execution path so semantic requests delegate to `skadi-server` via HTTP. `skadi-sql-gateway` intentionally untouched — SQL gateway convergence is a separate future question tracked in DQR-004.
+
+### What was built in E1
+
+| Capability | Key Components | Module |
+|---|---|---|
+| HTTP delegation | `SkadiServerQueryExecutionService` — replaces skeleton; POSTs to `POST /api/v1/queries`; handles cache-hit (200 SUCCEEDED) and async (202 ACCEPTED + status poll) paths | `skadi-semantic` |
+| Execution config | `SemanticExecutionProperties` (`skadi.semantic.execution.server-url`, `datasource-id`) | `skadi-server` |
+| Bean wiring | `queryExecutionService` bean added to `SemanticContractConfiguration` | `skadi-server` |
+| Tests | `SemanticExecutionActivationTest` (5 tests) + updated `ServiceBoundaryTest` (4 delegation tests) + updated `ContractCompositionTest` | `skadi-server`, `skadi-semantic` |
+
+### Key design decisions
+
+| Decision | Outcome |
+|---|---|
+| Execution delegation topology | DQR-002 resolved: Option 4 (partial convergence) — semantic path delegates to `skadi-server`; SQL gateway direct path unchanged |
+| SQL gateway convergence | Explicitly deferred; tracked as future scope in DQR-004 |
+| `skadi-sql-gateway` | **Untouched** — no changes to gateway module in Lane E |
+| Test approach | Hand-rolled JDK `HttpServer` fakes — no Mockito, no Databricks, no Spring context |
+
+### Test count progression
+
+| Milestone | skadi-semantic | skadi-server | Total |
+|---|---|---|---|
+| D7 complete (baseline) | 378 | 116 | 494 |
+| E1 complete | 524 | 186 | 710 |
+
+### Lane E non-goals (enforced throughout)
+
+- No `skadi-sql-gateway` changes
+- No SQL gateway traffic routed through `skadi-server`
+- No convergence of gateway and server execution ownership
+- No pgwire/mysql semantic awareness
+- No full gateway convergence (deferred to DQR-004)
+
+---
+
+## Architecture Evolution (Lane C+/D+/E+)
 
 Architecture docs, ADRs, and DQRs:
 
@@ -341,10 +390,11 @@ Architecture docs, ADRs, and DQRs:
 - `ai/adr/ADR-011-contract-definition-format-json-canonical.md` — JSON canonical for Lane D (Accepted)
 - `ai/adr/ADR-012-buddy-chat-semantic-model-interrogation.md` — buddy chat must interrogate semantic model for query execution and explanation; must not maintain independent business definitions (Accepted)
 - `ai/dqr/DQR-001-contract-definition-format.md` — **Resolved** (JSON canonical; YAML deferred)
-- `ai/dqr/DQR-002-semantic-execution-delegation.md` — execution topology (Open)
+- `ai/dqr/DQR-002-semantic-execution-delegation.md` — **Resolved** (Option 4 — partial convergence; issue #97)
 - `ai/dqr/DQR-003-lineage-market-risk-brain-seams.md` — lineage/MRB integration seams (Open)
+- `ai/dqr/DQR-004-sql-gateway-convergence.md` — full SQL gateway / semantic execution convergence (Open; future scope)
 
-Lane D is complete. Contracts are loadable, validateable, resolvable, and inspectable via a read-only HTTP endpoint. The semantic execution path (`SkadiServerQueryExecutionService`) remains a skeleton pending DQR-002 resolution. See `ai/lane-d/lane-d-runbook.md` for activation guidance and next-lane recommendations.
+Lane D is complete. Contracts are loadable, validateable, resolvable, and inspectable via a read-only HTTP endpoint. Lane E E1 activated `SkadiServerQueryExecutionService` — the semantic execution path now delegates to `skadi-server` via HTTP (DQR-002 resolved). SQL gateway convergence remains a future design question; see DQR-004.
 
 ---
 

--- a/ai/dqr/DQR-002-semantic-execution-delegation.md
+++ b/ai/dqr/DQR-002-semantic-execution-delegation.md
@@ -1,10 +1,10 @@
 # DQR-002: Semantic Execution Delegation
 
-**Status:** Open
+**Status:** Resolved — Option 4 (partial convergence)
 **Raised:** 2026-05-14
-**Blocking:** post-C5 activation of `SkadiserverSemanticExecutor`
+**Resolved:** 2026-05-17 — issue #97, PR #102, commit `42e4a4a`
 **Related:** ADR-004, ADR-008, ADR-010, dev-status debt item L10
-**Resolves in:** first post-Lane C story that activates live semantic execution
+**Follow-on:** DQR-004 tracks the remaining full SQL gateway convergence question
 
 ---
 
@@ -74,52 +74,35 @@ The answer affects:
 
 ---
 
-## Current Leaning
+## Resolution
 
-**Option 4** (partial convergence) is the most pragmatic next step:
+**Option 4 chosen** — partial convergence, implemented in issue #97.
 
-- Implement `SkadiserverSemanticExecutor` to call `POST /api/v1/queries` as ADR-004
-  proposes.
-- Leave the gateway's direct JDBC path unchanged for now — the gateway is
-  production-critical and convergence is a separate risk to manage.
-- Plan full convergence (Option 3) as a later dedicated story after the semantic path
-  is proven stable.
-
-This matches the ADR-004 rollout plan (C5 activates `skadi-server` for semantic path)
-while not over-committing to gateway changes.
+- `SkadiServerQueryExecutionService` now makes real HTTP calls to `POST /api/v1/queries`
+  on `skadi-server`. Cache-hit (200 SUCCEEDED) and async (202 ACCEPTED + status poll)
+  paths are both handled.
+- `skadi-sql-gateway` was **intentionally left unchanged** — the gateway's direct JDBC
+  path continues unaffected. This was an explicit guardrail for Lane E.
+- Full SQL gateway convergence (Option 3) is a separate future question. It should
+  only be attempted after the semantic path has proven stable in production. See DQR-004.
 
 ---
 
-## Risk Summary
+## Risk Summary (for reference)
 
-**If delegated to `skadi-server` (Options 1 or 4) and `skadi-server` is unavailable:**
+**`skadi-server` unavailable (the live risk under Option 4):**
 
-- Semantic queries fail; raw SQL path (gateway) continues unaffected.
-- A circuit breaker or health check in `skadi-semantic` is required to prevent
-  cascading failures.
+- Semantic queries fail; raw SQL gateway path continues unaffected.
+- A circuit breaker or health check is a future hardening item — not in scope for Lane E.
 
-**If semantic layer calls Databricks directly (Option 2):**
+**Full convergence (Option 3) — still not done:**
 
-- Cache sharing between paths breaks; two independent caches produce stale-result risks
-  and inflated Databricks costs.
-- Contradicts ADR-010's cache positioning decision.
-
-**If full convergence is attempted prematurely (Option 3):**
-
-- The gateway change is high-blast-radius; production Tableau connections are affected.
-- Full convergence should follow a production soak period of the semantic path.
-
-**If delayed indefinitely:**
-
-- `skadi-server` remains built but uncalled — a permanent dead weight in the codebase.
-- Cache deduplication between the two paths is never achieved.
-- Lane D bricks cannot use the live semantic endpoint.
+- Gateway change is high-blast-radius; production Tableau connections affected.
+- Deferred to DQR-004 and a future lane after production soak.
 
 ---
 
 ## Decision Status
 
-**Not yet decided.** Option 4 is the current leaning. The decision is confirmed when
-the post-Lane C story to activate `SkadiserverSemanticExecutor` is started. At that
-point, this DQR is marked Resolved and the activation approach is recorded in the
-commit message or a new ADR.
+**Resolved.** Option 4 implemented in issue #97 (commit `42e4a4a`, PR #102).
+Full gateway convergence tracked separately in DQR-004.

--- a/ai/dqr/DQR-004-sql-gateway-convergence.md
+++ b/ai/dqr/DQR-004-sql-gateway-convergence.md
@@ -1,0 +1,94 @@
+# DQR-004: Full SQL Gateway / Semantic Execution Convergence
+
+**Status:** Open
+**Raised:** 2026-05-17 (split from DQR-002 after issue #97 resolved partial convergence)
+**Blocking:** no current lane; future scope only
+**Related:** DQR-002 (resolved), ADR-004, ADR-010, dev-status debt item L10
+**Resolves in:** a dedicated future story after the semantic path has production soak
+
+---
+
+## Scope
+
+DQR-002 resolved the question of how the semantic layer delegates to `skadi-server`
+(Option 4 — partial convergence). One part of the original question was explicitly
+**not decided** and is tracked here:
+
+> Should the SQL gateway's raw SQL path also route through `skadi-server`, eliminating
+> the dual-path topology and the two-pool / two-cache problem?
+
+`skadi-sql-gateway` was **intentionally untouched** in Lane E. This DQR records why
+that decision was made, what the remaining trade-offs are, and what would need to be
+true before full convergence is attempted.
+
+---
+
+## Context
+
+After Lane E E1 (issue #97), the execution topology is:
+
+```
+BI tool (Tableau/psql)
+  └─► skadi-sql-gateway  ──► Databricks (direct JDBC, own pool, own cache)
+
+Semantic API consumer
+  └─► SkadiServerQueryExecutionService  ──► skadi-server  ──► Databricks
+```
+
+Two JDBC pools, two cache owners, two execution paths. This is the "partial
+convergence" state DQR-002 Option 4 accepted as the pragmatic next step.
+
+Debt item **L10** documents the longer-term concern:
+> "Gateway embeds own JDBC pool + cache instead of delegating to `skadi-server` —
+> duplicates execution concerns."
+
+---
+
+## The question
+
+Should a future lane route SQL gateway queries through `skadi-server` as well,
+converging to a single JDBC pool, a single cache, and a single execution authority?
+
+This is Option 3 from DQR-002:
+
+| Approach | Summary |
+|---|---|
+| Full convergence (Option 3) | Both gateway and semantic path delegate JDBC to `skadi-server`. Single pool, single cache, resolves L10 fully. |
+| Stay on partial convergence (Option 4, current) | Gateway keeps its direct JDBC path. Two pools and caches persist. L10 remains a known limitation. |
+
+---
+
+## Why full convergence was deferred
+
+1. **Blast radius.** `skadi-sql-gateway` is production-critical for Tableau Server /
+   Cloud. Routing gateway traffic through an additional HTTP hop adds a new failure
+   point for active users.
+2. **Scope discipline.** Lane E was scoped to semantic execution activation only.
+   Gateway changes are a separate architectural move with their own risk profile.
+3. **Soak first.** The semantic-to-`skadi-server` delegation path added in Lane E
+   should prove stable before the higher-traffic gateway path is rerouted.
+
+---
+
+## What full convergence would require
+
+- A decision that `skadi-server` is the single JDBC/cache authority for all paths.
+- A rollout plan that preserves Tableau connectivity throughout the migration.
+- Either a feature flag or a blue/green approach to avoid a flag-day cutover.
+- Extended test coverage for the gateway-through-server path under realistic Tableau
+  query patterns (golden-result harness from B4 is relevant).
+- Resolution of latency implications: the extra HTTP hop affects p50/p95 for
+  interactive Tableau queries.
+
+---
+
+## Decision status
+
+**Not yet decided.** Full convergence is explicitly future scope. This DQR should be
+revisited after:
+
+1. The Lane E semantic path has had meaningful production use.
+2. The performance impact of the extra HTTP hop has been measured.
+3. A future lane (candidate: Lane F or a dedicated convergence lane) is scoped.
+
+Do not converge the SQL gateway in the absence of a deliberate decision here.


### PR DESCRIPTION
- dev-status.md: add Lane E E1 story table and completion summary; update header to reflect 710 tests passing; update DQR-002 status to Resolved; add DQR-004 reference for SQL gateway convergence
- DQR-002: mark Resolved (Option 4 chosen, issue #97); document that skadi-sql-gateway was intentionally untouched; point to DQR-004 for the remaining full-convergence question
- DQR-004: new — records the full SQL gateway / semantic execution convergence as open future scope; explicit that gateway convergence must not happen without a deliberate decision here

No production code or test changes.