### PR TITLE
Lane E E2: semantic execution observability and diagnostics (skadi#104)

### DIFF
--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -1,9 +1,9 @@
 # Skadi — Development Status
 
 > Updated: 2026-05-17
-> Branch: `main`
-> Last commit: `2f53fa4` — docs: add buddy chat semantic model interrogation decision (ADR-012)
-> Build: ✅ 494 tests passing (`mvn verify -pl skadi-semantic,skadi-server -am`; gateway test counts unchanged)
+> Branch: `feature/97-lane-e-semantic-execution-activation`
+> Last commit: `42e4a4a` — Lane E semantic execution activation — skadi#97
+> Build: ✅ 710 tests passing (`mvn verify -pl skadi-semantic,skadi-server -am`; gateway test counts unchanged)
 
 ---
 
@@ -157,7 +157,7 @@ Items prefixed `[critical]` should be addressed before production traffic.
 
 | ID | Severity | Detail |
 |---|---|---|
-| L10 | Medium | Gateway embeds own JDBC pool + cache instead of delegating to `skadi-server` — duplicates execution concerns; `SkadiServerQueryExecutionService` skeleton created in Lane C; HTTP activation deferred pending DQR-002 resolution |
+| L10 | Medium | Gateway embeds own JDBC pool + cache instead of delegating to `skadi-server` — duplicates execution concerns; `SkadiServerQueryExecutionService` activated in Lane E (DQR-002 resolved); full SQL gateway convergence remains deferred — see DQR-004 |
 | L11 | Low | `JdbcArrowStreamer` duplicated in `skadi-core` and `skadi-server`; copies may diverge |
 | L13 | Low | `ai/query-flow.md` referenced in `ai/claude-instructions.md` but does not exist |
 
@@ -326,7 +326,56 @@ All D-lane issues closed. Committed directly to `main`.
 
 ---
 
-## Architecture Evolution (Lane C+/D+)
+## Lane E — Semantic Execution Activation (In Progress)
+
+| Story | Description | Status | Commit | Issue |
+|---|---|---|---|---|
+| E1 | Semantic execution activation (`SkadiServerQueryExecutionService`) | ✅ | `42e4a4a` | #97 |
+
+---
+
+## Lane E Completed — E1 Summary
+
+**Issue:** #97 | **PR:** #102 | **Commit:** `42e4a4a`
+
+**Lane E E1 scope:** Activate the semantic execution path so semantic requests delegate to `skadi-server` via HTTP. `skadi-sql-gateway` intentionally untouched — SQL gateway convergence is a separate future question tracked in DQR-004.
+
+### What was built in E1
+
+| Capability | Key Components | Module |
+|---|---|---|
+| HTTP delegation | `SkadiServerQueryExecutionService` — replaces skeleton; POSTs to `POST /api/v1/queries`; handles cache-hit (200 SUCCEEDED) and async (202 ACCEPTED + status poll) paths | `skadi-semantic` |
+| Execution config | `SemanticExecutionProperties` (`skadi.semantic.execution.server-url`, `datasource-id`) | `skadi-server` |
+| Bean wiring | `queryExecutionService` bean added to `SemanticContractConfiguration` | `skadi-server` |
+| Tests | `SemanticExecutionActivationTest` (5 tests) + updated `ServiceBoundaryTest` (4 delegation tests) + updated `ContractCompositionTest` | `skadi-server`, `skadi-semantic` |
+
+### Key design decisions
+
+| Decision | Outcome |
+|---|---|
+| Execution delegation topology | DQR-002 resolved: Option 4 (partial convergence) — semantic path delegates to `skadi-server`; SQL gateway direct path unchanged |
+| SQL gateway convergence | Explicitly deferred; tracked as future scope in DQR-004 |
+| `skadi-sql-gateway` | **Untouched** — no changes to gateway module in Lane E |
+| Test approach | Hand-rolled JDK `HttpServer` fakes — no Mockito, no Databricks, no Spring context |
+
+### Test count progression
+
+| Milestone | skadi-semantic | skadi-server | Total |
+|---|---|---|---|
+| D7 complete (baseline) | 378 | 116 | 494 |
+| E1 complete | 524 | 186 | 710 |
+
+### Lane E non-goals (enforced throughout)
+
+- No `skadi-sql-gateway` changes
+- No SQL gateway traffic routed through `skadi-server`
+- No convergence of gateway and server execution ownership
+- No pgwire/mysql semantic awareness
+- No full gateway convergence (deferred to DQR-004)
+
+---
+
+## Architecture Evolution (Lane C+/D+/E+)
 
 Architecture docs, ADRs, and DQRs:
 
@@ -341,10 +390,11 @@ Architecture docs, ADRs, and DQRs:
 - `ai/adr/ADR-011-contract-definition-format-json-canonical.md` — JSON canonical for Lane D (Accepted)
 - `ai/adr/ADR-012-buddy-chat-semantic-model-interrogation.md` — buddy chat must interrogate semantic model for query execution and explanation; must not maintain independent business definitions (Accepted)
 - `ai/dqr/DQR-001-contract-definition-format.md` — **Resolved** (JSON canonical; YAML deferred)
-- `ai/dqr/DQR-002-semantic-execution-delegation.md` — execution topology (Open)
+- `ai/dqr/DQR-002-semantic-execution-delegation.md` — **Resolved** (Option 4 — partial convergence; issue #97)
 - `ai/dqr/DQR-003-lineage-market-risk-brain-seams.md` — lineage/MRB integration seams (Open)
+- `ai/dqr/DQR-004-sql-gateway-convergence.md` — full SQL gateway / semantic execution convergence (Open; future scope)
 
-Lane D is complete. Contracts are loadable, validateable, resolvable, and inspectable via a read-only HTTP endpoint. The semantic execution path (`SkadiServerQueryExecutionService`) remains a skeleton pending DQR-002 resolution. See `ai/lane-d/lane-d-runbook.md` for activation guidance and next-lane recommendations.
+Lane D is complete. Contracts are loadable, validateable, resolvable, and inspectable via a read-only HTTP endpoint. Lane E E1 activated `SkadiServerQueryExecutionService` — the semantic execution path now delegates to `skadi-server` via HTTP (DQR-002 resolved). SQL gateway convergence remains a future design question; see DQR-004.
 
 ---
 

--- a/ai/dqr/DQR-002-semantic-execution-delegation.md
+++ b/ai/dqr/DQR-002-semantic-execution-delegation.md
@@ -1,10 +1,10 @@
 # DQR-002: Semantic Execution Delegation
 
-**Status:** Open
+**Status:** Resolved — Option 4 (partial convergence)
 **Raised:** 2026-05-14
-**Blocking:** post-C5 activation of `SkadiserverSemanticExecutor`
+**Resolved:** 2026-05-17 — issue #97, PR #102, commit `42e4a4a`
 **Related:** ADR-004, ADR-008, ADR-010, dev-status debt item L10
-**Resolves in:** first post-Lane C story that activates live semantic execution
+**Follow-on:** DQR-004 tracks the remaining full SQL gateway convergence question
 
 ---
 
@@ -74,52 +74,35 @@ The answer affects:
 
 ---
 
-## Current Leaning
+## Resolution
 
-**Option 4** (partial convergence) is the most pragmatic next step:
+**Option 4 chosen** — partial convergence, implemented in issue #97.
 
-- Implement `SkadiserverSemanticExecutor` to call `POST /api/v1/queries` as ADR-004
-  proposes.
-- Leave the gateway's direct JDBC path unchanged for now — the gateway is
-  production-critical and convergence is a separate risk to manage.
-- Plan full convergence (Option 3) as a later dedicated story after the semantic path
-  is proven stable.
-
-This matches the ADR-004 rollout plan (C5 activates `skadi-server` for semantic path)
-while not over-committing to gateway changes.
+- `SkadiServerQueryExecutionService` now makes real HTTP calls to `POST /api/v1/queries`
+  on `skadi-server`. Cache-hit (200 SUCCEEDED) and async (202 ACCEPTED + status poll)
+  paths are both handled.
+- `skadi-sql-gateway` was **intentionally left unchanged** — the gateway's direct JDBC
+  path continues unaffected. This was an explicit guardrail for Lane E.
+- Full SQL gateway convergence (Option 3) is a separate future question. It should
+  only be attempted after the semantic path has proven stable in production. See DQR-004.
 
 ---
 
-## Risk Summary
+## Risk Summary (for reference)
 
-**If delegated to `skadi-server` (Options 1 or 4) and `skadi-server` is unavailable:**
+**`skadi-server` unavailable (the live risk under Option 4):**
 
-- Semantic queries fail; raw SQL path (gateway) continues unaffected.
-- A circuit breaker or health check in `skadi-semantic` is required to prevent
-  cascading failures.
+- Semantic queries fail; raw SQL gateway path continues unaffected.
+- A circuit breaker or health check is a future hardening item — not in scope for Lane E.
 
-**If semantic layer calls Databricks directly (Option 2):**
+**Full convergence (Option 3) — still not done:**
 
-- Cache sharing between paths breaks; two independent caches produce stale-result risks
-  and inflated Databricks costs.
-- Contradicts ADR-010's cache positioning decision.
-
-**If full convergence is attempted prematurely (Option 3):**
-
-- The gateway change is high-blast-radius; production Tableau connections are affected.
-- Full convergence should follow a production soak period of the semantic path.
-
-**If delayed indefinitely:**
-
-- `skadi-server` remains built but uncalled — a permanent dead weight in the codebase.
-- Cache deduplication between the two paths is never achieved.
-- Lane D bricks cannot use the live semantic endpoint.
+- Gateway change is high-blast-radius; production Tableau connections affected.
+- Deferred to DQR-004 and a future lane after production soak.
 
 ---
 
 ## Decision Status
 
-**Not yet decided.** Option 4 is the current leaning. The decision is confirmed when
-the post-Lane C story to activate `SkadiserverSemanticExecutor` is started. At that
-point, this DQR is marked Resolved and the activation approach is recorded in the
-commit message or a new ADR.
+**Resolved.** Option 4 implemented in issue #97 (commit `42e4a4a`, PR #102).
+Full gateway convergence tracked separately in DQR-004.

--- a/ai/dqr/DQR-004-sql-gateway-convergence.md
+++ b/ai/dqr/DQR-004-sql-gateway-convergence.md
@@ -1,0 +1,94 @@
+# DQR-004: Full SQL Gateway / Semantic Execution Convergence
+
+**Status:** Open
+**Raised:** 2026-05-17 (split from DQR-002 after issue #97 resolved partial convergence)
+**Blocking:** no current lane; future scope only
+**Related:** DQR-002 (resolved), ADR-004, ADR-010, dev-status debt item L10
+**Resolves in:** a dedicated future story after the semantic path has production soak
+
+---
+
+## Scope
+
+DQR-002 resolved the question of how the semantic layer delegates to `skadi-server`
+(Option 4 — partial convergence). One part of the original question was explicitly
+**not decided** and is tracked here:
+
+> Should the SQL gateway's raw SQL path also route through `skadi-server`, eliminating
+> the dual-path topology and the two-pool / two-cache problem?
+
+`skadi-sql-gateway` was **intentionally untouched** in Lane E. This DQR records why
+that decision was made, what the remaining trade-offs are, and what would need to be
+true before full convergence is attempted.
+
+---
+
+## Context
+
+After Lane E E1 (issue #97), the execution topology is:
+
+```
+BI tool (Tableau/psql)
+  └─► skadi-sql-gateway  ──► Databricks (direct JDBC, own pool, own cache)
+
+Semantic API consumer
+  └─► SkadiServerQueryExecutionService  ──► skadi-server  ──► Databricks
+```
+
+Two JDBC pools, two cache owners, two execution paths. This is the "partial
+convergence" state DQR-002 Option 4 accepted as the pragmatic next step.
+
+Debt item **L10** documents the longer-term concern:
+> "Gateway embeds own JDBC pool + cache instead of delegating to `skadi-server` —
+> duplicates execution concerns."
+
+---
+
+## The question
+
+Should a future lane route SQL gateway queries through `skadi-server` as well,
+converging to a single JDBC pool, a single cache, and a single execution authority?
+
+This is Option 3 from DQR-002:
+
+| Approach | Summary |
+|---|---|
+| Full convergence (Option 3) | Both gateway and semantic path delegate JDBC to `skadi-server`. Single pool, single cache, resolves L10 fully. |
+| Stay on partial convergence (Option 4, current) | Gateway keeps its direct JDBC path. Two pools and caches persist. L10 remains a known limitation. |
+
+---
+
+## Why full convergence was deferred
+
+1. **Blast radius.** `skadi-sql-gateway` is production-critical for Tableau Server /
+   Cloud. Routing gateway traffic through an additional HTTP hop adds a new failure
+   point for active users.
+2. **Scope discipline.** Lane E was scoped to semantic execution activation only.
+   Gateway changes are a separate architectural move with their own risk profile.
+3. **Soak first.** The semantic-to-`skadi-server` delegation path added in Lane E
+   should prove stable before the higher-traffic gateway path is rerouted.
+
+---
+
+## What full convergence would require
+
+- A decision that `skadi-server` is the single JDBC/cache authority for all paths.
+- A rollout plan that preserves Tableau connectivity throughout the migration.
+- Either a feature flag or a blue/green approach to avoid a flag-day cutover.
+- Extended test coverage for the gateway-through-server path under realistic Tableau
+  query patterns (golden-result harness from B4 is relevant).
+- Resolution of latency implications: the extra HTTP hop affects p50/p95 for
+  interactive Tableau queries.
+
+---
+
+## Decision status
+
+**Not yet decided.** Full convergence is explicitly future scope. This DQR should be
+revisited after:
+
+1. The Lane E semantic path has had meaningful production use.
+2. The performance impact of the extra HTTP hop has been measured.
+3. A future lane (candidate: Lane F or a dedicated convergence lane) is scoped.
+
+Do not converge the SQL gateway in the absence of a deliberate decision here.

--- a/skadi-semantic/pom.xml
+++ b/skadi-semantic/pom.xml
@@ -36,6 +36,13 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+
+    <!-- SLF4J: structured logging in SkadiServerQueryExecutionService (Lane E E2) -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.13</version>
+    </dependency>
     <!-- JavaTimeModule for Instant fields in cache boundary types — test only -->
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/NoOpSemanticExecutionMetrics.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/NoOpSemanticExecutionMetrics.java
@@ -1,0 +1,23 @@
+package org.iceforge.skadi.semantic.service;
+
+/**
+ * A no-op {@link SemanticExecutionMetrics} for tests and unconfigured deployments.
+ *
+ * <p>All methods are empty. Use {@link #INSTANCE} wherever a {@link SemanticExecutionMetrics}
+ * is required but no real recording is needed.
+ */
+public final class NoOpSemanticExecutionMetrics implements SemanticExecutionMetrics {
+
+    /** Singleton instance — this class has no state. */
+    public static final NoOpSemanticExecutionMetrics INSTANCE = new NoOpSemanticExecutionMetrics();
+
+    private NoOpSemanticExecutionMetrics() {}
+
+    @Override public void recordAttempt()       {}
+    @Override public void recordCacheHit()      {}
+    @Override public void recordAsyncAccepted() {}
+    @Override public void recordSuccess()       {}
+    @Override public void recordFailure()       {}
+    @Override public void recordTimeout()       {}
+    @Override public void recordError()         {}
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SemanticExecutionMetrics.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SemanticExecutionMetrics.java
@@ -1,0 +1,43 @@
+package org.iceforge.skadi.semantic.service;
+
+/**
+ * Observability callback for {@link SkadiServerQueryExecutionService} execution paths.
+ *
+ * <p>Implementations record counters or metrics for each outcome of a semantic execution
+ * attempt. The default no-op implementation is {@link NoOpSemanticExecutionMetrics}.
+ *
+ * <p>Every call to {@link QueryExecutionService#execute} triggers exactly one
+ * {@link #recordAttempt()} followed by exactly one terminal counter:
+ * {@link #recordCacheHit()}, {@link #recordSuccess()}, {@link #recordFailure()},
+ * {@link #recordTimeout()}, or {@link #recordError()}. Async queries additionally
+ * trigger {@link #recordAsyncAccepted()} between attempt and the terminal counter.
+ *
+ * <p>Implementations must be thread-safe.
+ */
+public interface SemanticExecutionMetrics {
+
+    /** Called at the start of every {@code execute()} invocation. */
+    void recordAttempt();
+
+    /** Called when the submit response is {@code 200 SUCCEEDED} (cache hit on server). */
+    void recordCacheHit();
+
+    /**
+     * Called when the submit response is {@code 202 ACCEPTED} — the query started
+     * asynchronously and polling will follow.
+     */
+    void recordAsyncAccepted();
+
+    /** Called when a polled query reaches {@code SUCCEEDED} state. */
+    void recordSuccess();
+
+    /** Called when a query reaches {@code FAILED} or {@code CANCELED} state, or when
+     *  the submit response is an unexpected non-success. */
+    void recordFailure();
+
+    /** Called when polling exhausts the max-wait deadline without a terminal state. */
+    void recordTimeout();
+
+    /** Called when an unexpected exception propagates from the HTTP layer. */
+    void recordError();
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SkadiServerQueryExecutionService.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SkadiServerQueryExecutionService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.iceforge.skadi.semantic.cache.CacheEntryState;
 import org.iceforge.skadi.semantic.cache.CacheIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -28,10 +30,13 @@ import java.util.Objects;
  *       {@code /api/v1/queries/{queryId}/status} until a terminal state is reached.</li>
  * </ol>
  *
- * <p>Wired as a Spring bean by {@code SemanticContractConfiguration} in {@code skadi-server}
- * via {@code skadi.semantic.execution.*} properties.
+ * <p>Observability: every execution path emits structured SLF4J log events and records
+ * counters via {@link SemanticExecutionMetrics}. Wired as a Spring bean by
+ * {@code SemanticContractConfiguration} in {@code skadi-server}.
  */
 public final class SkadiServerQueryExecutionService implements QueryExecutionService {
+
+    private static final Logger log = LoggerFactory.getLogger(SkadiServerQueryExecutionService.class);
 
     static final long DEFAULT_POLL_INTERVAL_MS = 500L;
     static final long DEFAULT_MAX_WAIT_MS = 300_000L;
@@ -44,9 +49,11 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
     private final HttpClient httpClient;
     private final long pollIntervalMs;
     private final long maxWaitMs;
+    private final SemanticExecutionMetrics metrics;
 
     /**
-     * Production constructor. Uses the default {@link HttpClient} and standard poll settings.
+     * Convenience constructor. Uses {@link NoOpSemanticExecutionMetrics}, the default
+     * {@link HttpClient}, and standard poll settings.
      *
      * @param baseUrl      skadi-server base URL (e.g. {@code http://localhost:8080})
      * @param jdbcUrl      JDBC URL forwarded to skadi-server for Databricks connections
@@ -61,7 +68,29 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
             String jdbcPassword,
             ObjectMapper mapper) {
         this(baseUrl, jdbcUrl, jdbcUsername, jdbcPassword, mapper,
-                HttpClient.newHttpClient(), DEFAULT_POLL_INTERVAL_MS, DEFAULT_MAX_WAIT_MS);
+                NoOpSemanticExecutionMetrics.INSTANCE);
+    }
+
+    /**
+     * Production constructor. Uses the default {@link HttpClient} and standard poll settings.
+     *
+     * @param baseUrl      skadi-server base URL (e.g. {@code http://localhost:8080})
+     * @param jdbcUrl      JDBC URL forwarded to skadi-server for Databricks connections
+     * @param jdbcUsername optional JDBC username; may be null
+     * @param jdbcPassword optional JDBC password; may be null
+     * @param mapper       Jackson ObjectMapper for JSON request/response handling
+     * @param metrics      observability callback; use {@link NoOpSemanticExecutionMetrics#INSTANCE}
+     *                     when no real recording is needed
+     */
+    public SkadiServerQueryExecutionService(
+            String baseUrl,
+            String jdbcUrl,
+            String jdbcUsername,
+            String jdbcPassword,
+            ObjectMapper mapper,
+            SemanticExecutionMetrics metrics) {
+        this(baseUrl, jdbcUrl, jdbcUsername, jdbcPassword, mapper,
+                HttpClient.newHttpClient(), DEFAULT_POLL_INTERVAL_MS, DEFAULT_MAX_WAIT_MS, metrics);
     }
 
     /** Package-private: allows tests to inject a fake {@link HttpClient} and tunable poll timing. */
@@ -73,7 +102,8 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
             ObjectMapper mapper,
             HttpClient httpClient,
             long pollIntervalMs,
-            long maxWaitMs) {
+            long maxWaitMs,
+            SemanticExecutionMetrics metrics) {
         String trimmed = Objects.requireNonNull(baseUrl, "baseUrl");
         this.baseUrl = trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
         this.jdbcUrl = Objects.requireNonNull(jdbcUrl, "jdbcUrl");
@@ -83,6 +113,7 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
         this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
         this.pollIntervalMs = pollIntervalMs;
         this.maxWaitMs = maxWaitMs;
+        this.metrics = Objects.requireNonNull(metrics, "metrics");
     }
 
     /**
@@ -105,8 +136,12 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
                     "SQL-first execution required for Lane E; request.sql() must not be blank");
         }
 
+        String principal = request.context().principalName();
         CacheIdentity identity = new CacheIdentity(
-                sql, request.context().principalName(), request.semanticContractName());
+                sql, principal, request.semanticContractName());
+
+        log.debug("semantic-exec: attempt principal={} server={}", principal, baseUrl);
+        metrics.recordAttempt();
 
         try {
             String body = buildSubmitBody(sql);
@@ -124,20 +159,33 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
             String state = resp.path("state").asText("");
 
             if (response.statusCode() == 200 && "SUCCEEDED".equals(state)) {
+                log.info("semantic-exec: cache-hit queryId={} principal={}", queryId, principal);
+                metrics.recordCacheHit();
                 return QueryExecutionResult.completed(request.context(), identity, CacheEntryState.FRESH);
             }
             if (response.statusCode() == 202 && queryId != null) {
+                log.info("semantic-exec: async-accepted queryId={} principal={}", queryId, principal);
+                metrics.recordAsyncAccepted();
                 return pollUntilDone(request.context(), identity, queryId);
             }
+
+            log.warn("semantic-exec: unexpected-submit-response http={} state={} principal={}",
+                    response.statusCode(), state, principal);
+            metrics.recordFailure();
             return QueryExecutionResult.failed(request.context(), identity,
                     "unexpected submit response: HTTP " + response.statusCode() + " state=" + state);
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            log.warn("semantic-exec: interrupted principal={}", principal);
+            metrics.recordError();
             return QueryExecutionResult.failed(request.context(), identity,
                     "interrupted while waiting for query: " + e.getMessage());
         } catch (Exception e) {
-            return QueryExecutionResult.failed(request.context(), identity, e.getMessage());
+            String msg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            log.error("semantic-exec: error principal={} msg={}", principal, msg, e);
+            metrics.recordError();
+            return QueryExecutionResult.failed(request.context(), identity, msg);
         }
     }
 
@@ -167,18 +215,29 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
             JsonNode statusNode = mapper.readTree(statusResp.body());
             String state = statusNode.path("state").asText("");
 
+            log.debug("semantic-exec: poll queryId={} state={}", queryId, state);
+
             if ("SUCCEEDED".equals(state)) {
+                log.info("semantic-exec: succeeded queryId={} principal={}", queryId, ctx.principalName());
+                metrics.recordSuccess();
                 return QueryExecutionResult.completed(ctx, identity, CacheEntryState.ABSENT);
             }
             if ("FAILED".equals(state)) {
-                return QueryExecutionResult.failed(ctx, identity,
-                        statusNode.path("message").asText("query failed on server"));
+                String msg = statusNode.path("message").asText("query failed on server");
+                log.warn("semantic-exec: failed queryId={} msg={}", queryId, msg);
+                metrics.recordFailure();
+                return QueryExecutionResult.failed(ctx, identity, msg);
             }
             if ("CANCELED".equals(state)) {
+                log.warn("semantic-exec: canceled queryId={}", queryId);
+                metrics.recordFailure();
                 return QueryExecutionResult.failed(ctx, identity, "query was canceled on server");
             }
             // QUEUED or RUNNING — keep polling
         }
+
+        log.warn("semantic-exec: timeout queryId={} maxWaitMs={}", queryId, maxWaitMs);
+        metrics.recordTimeout();
         return QueryExecutionResult.failed(ctx, identity, "query timed out after " + maxWaitMs + "ms");
     }
 }

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/SemanticExecutionMetricsTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/SemanticExecutionMetricsTest.java
@@ -1,0 +1,199 @@
+package org.iceforge.skadi.semantic.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.iceforge.skadi.semantic.cache.CacheContract;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that {@link SkadiServerQueryExecutionService} calls the correct
+ * {@link SemanticExecutionMetrics} counters for each execution path.
+ *
+ * <p>Uses hand-rolled JDK {@code HttpServer} fakes and a capturing
+ * {@link SemanticExecutionMetrics} stub — no Mockito, no Databricks.
+ */
+class SemanticExecutionMetricsTest {
+
+    private static final String SQL = "SELECT 1";
+    private static final ExecutionContext CTX = ExecutionContext.of("alice");
+
+    // ── NoOpSemanticExecutionMetrics ──────────────────────────────────────────
+
+    @Test
+    void noOp_allMethodsAreSilent() {
+        var m = NoOpSemanticExecutionMetrics.INSTANCE;
+        assertDoesNotThrow(() -> {
+            m.recordAttempt();
+            m.recordCacheHit();
+            m.recordAsyncAccepted();
+            m.recordSuccess();
+            m.recordFailure();
+            m.recordTimeout();
+            m.recordError();
+        });
+    }
+
+    // ── Cache-hit path ────────────────────────────────────────────────────────
+
+    @Test
+    void cacheHit_recordsAttemptAndCacheHit() throws Exception {
+        var capture = new CapturingMetrics();
+        String resp = "{\"queryId\":\"q1\",\"state\":\"SUCCEEDED\",\"resultUrl\":\"/r\",\"expiresAt\":\"2030-01-01T00:00:00Z\"}";
+
+        try (var fake = FakeServer.returning(200, resp)) {
+            service(fake.baseUrl(), capture)
+                    .execute(QueryExecutionRequest.sqlOnly(CTX, SQL, CacheContract.none()));
+        }
+
+        assertEquals(1, capture.attempts);
+        assertEquals(1, capture.cacheHits);
+        assertEquals(0, capture.asyncAccepted);
+        assertEquals(0, capture.successes);
+        assertEquals(0, capture.failures);
+        assertEquals(0, capture.timeouts);
+        assertEquals(0, capture.errors);
+    }
+
+    // ── Async path ────────────────────────────────────────────────────────────
+
+    @Test
+    void asyncQuery_recordsAttemptAsyncAndSuccess() throws Exception {
+        var capture = new CapturingMetrics();
+        AtomicInteger pollCount = new AtomicInteger();
+        String submitResp = "{\"queryId\":\"q2\",\"state\":\"QUEUED\",\"resultUrl\":\"/r\",\"expiresAt\":\"2030-01-01T00:00:00Z\"}";
+
+        try (var fake = FakeServer.asyncQuery(submitResp, pollCount)) {
+            service(fake.baseUrl(), capture)
+                    .execute(QueryExecutionRequest.sqlOnly(CTX, SQL, CacheContract.none()));
+        }
+
+        assertEquals(1, capture.attempts);
+        assertEquals(0, capture.cacheHits);
+        assertEquals(1, capture.asyncAccepted);
+        assertEquals(1, capture.successes);
+        assertEquals(0, capture.failures);
+        assertEquals(0, capture.timeouts);
+        assertEquals(0, capture.errors);
+    }
+
+    // ── Failure path ──────────────────────────────────────────────────────────
+
+    @Test
+    void unexpectedSubmitResponse_recordsFailure() throws Exception {
+        var capture = new CapturingMetrics();
+        // HTTP 200 but state=FAILED is not the cache-hit pattern (200+SUCCEEDED);
+        // falls through to the unexpected-response branch.
+        String resp = "{\"queryId\":\"q3\",\"state\":\"FAILED\",\"resultUrl\":\"/r\",\"expiresAt\":\"2030-01-01T00:00:00Z\"}";
+
+        try (var fake = FakeServer.returning(200, resp)) {
+            service(fake.baseUrl(), capture)
+                    .execute(QueryExecutionRequest.sqlOnly(CTX, SQL, CacheContract.none()));
+        }
+
+        assertEquals(1, capture.attempts);
+        assertEquals(0, capture.cacheHits);
+        assertEquals(1, capture.failures);
+        assertEquals(0, capture.errors);
+    }
+
+    // ── Error path ────────────────────────────────────────────────────────────
+
+    @Test
+    void connectionRefused_recordsError() {
+        var capture = new CapturingMetrics();
+        // Port 1 is unreachable — HTTP client will throw an exception.
+        var svc = service("http://localhost:1", capture);
+
+        var result = svc.execute(QueryExecutionRequest.sqlOnly(CTX, SQL, CacheContract.none()));
+
+        assertEquals(1, capture.attempts);
+        assertEquals(0, capture.cacheHits);
+        assertEquals(1, capture.errors);
+        assertEquals(ExecutionStatus.FAILED, result.status());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static SkadiServerQueryExecutionService service(String baseUrl, SemanticExecutionMetrics m) {
+        return new SkadiServerQueryExecutionService(
+                baseUrl, "jdbc:h2:mem:test", "sa", "",
+                new ObjectMapper(),
+                HttpClient.newHttpClient(),
+                /*pollIntervalMs=*/ 10L,
+                /*maxWaitMs=*/ 5_000L,
+                m);
+    }
+
+    static final class CapturingMetrics implements SemanticExecutionMetrics {
+        int attempts, cacheHits, asyncAccepted, successes, failures, timeouts, errors;
+
+        @Override public void recordAttempt()       { attempts++; }
+        @Override public void recordCacheHit()      { cacheHits++; }
+        @Override public void recordAsyncAccepted() { asyncAccepted++; }
+        @Override public void recordSuccess()       { successes++; }
+        @Override public void recordFailure()       { failures++; }
+        @Override public void recordTimeout()       { timeouts++; }
+        @Override public void recordError()         { errors++; }
+    }
+
+    static final class FakeServer implements AutoCloseable {
+
+        private final com.sun.net.httpserver.HttpServer server;
+
+        private FakeServer() throws Exception {
+            server = com.sun.net.httpserver.HttpServer.create(
+                    new java.net.InetSocketAddress(0), 0);
+        }
+
+        String baseUrl() {
+            return "http://localhost:" + server.getAddress().getPort();
+        }
+
+        @Override
+        public void close() { server.stop(0); }
+
+        static FakeServer returning(int status, String body) throws Exception {
+            var fake = new FakeServer();
+            fake.server.createContext("/api/v1/queries", exchange -> {
+                exchange.getRequestBody().readAllBytes();
+                byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(status, bytes.length);
+                exchange.getResponseBody().write(bytes);
+                exchange.close();
+            });
+            fake.server.start();
+            return fake;
+        }
+
+        static FakeServer asyncQuery(String submitResp, AtomicInteger pollCount) throws Exception {
+            var fake = new FakeServer();
+            fake.server.createContext("/api/v1/queries", exchange -> {
+                String path   = exchange.getRequestURI().getPath();
+                String method = exchange.getRequestMethod();
+                String payload;
+                int status;
+                if ("POST".equals(method) && "/api/v1/queries".equals(path)) {
+                    exchange.getRequestBody().readAllBytes();
+                    payload = submitResp;
+                    status  = 202;
+                } else {
+                    int count = pollCount.incrementAndGet();
+                    String state = count >= 2 ? "SUCCEEDED" : "RUNNING";
+                    payload = "{\"queryId\":\"q2\",\"state\":\"" + state + "\"}";
+                    status  = 200;
+                }
+                byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(status, bytes.length);
+                exchange.getResponseBody().write(bytes);
+                exchange.close();
+            });
+            fake.server.start();
+            return fake;
+        }
+    }
+}

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/ServiceBoundaryTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/ServiceBoundaryTest.java
@@ -348,7 +348,8 @@ class ServiceBoundaryTest {
                 new com.fasterxml.jackson.databind.ObjectMapper(),
                 java.net.http.HttpClient.newHttpClient(),
                 /*pollIntervalMs=*/ 10L,
-                /*maxWaitMs=*/ 5_000L);
+                /*maxWaitMs=*/ 5_000L,
+                NoOpSemanticExecutionMetrics.INSTANCE);
     }
 
     /**

--- a/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticContractConfiguration.java
+++ b/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticContractConfiguration.java
@@ -30,9 +30,12 @@ import java.util.List;
  *   <li>{@code semanticContractValidator} — stateless {@link SemanticContractValidator}</li>
  *   <li>{@code semanticContractResolver} — {@link RegistrySemanticContractResolver}
  *       backed by the registry</li>
- *   <li>{@code queryExecutionService} — Lane E: {@link SkadiServerQueryExecutionService}
+ *   <li>{@code queryExecutionService} — Lane E E1: {@link SkadiServerQueryExecutionService}
  *       that delegates semantic query execution to skadi-server's {@code POST /api/v1/queries}
  *       endpoint (DQR-002 resolved, Option 4 — partial convergence)</li>
+ *   <li>{@code semanticExecutionMetricsRegistry} — Lane E E2: {@link SemanticExecutionMetricsRegistry}
+ *       wired into the execution service; counters exposed via
+ *       {@code GET /api/semantic/v1/execution/status}</li>
  * </ul>
  *
  * <p>Safe-defaults: if {@code skadi.semantic.contracts.enabled} is {@code false}
@@ -110,11 +113,36 @@ public class SemanticContractConfiguration {
      * empty strings are substituted and the execution service will report a connection error
      * at runtime — server startup is not affected.
      */
+    /**
+     * Lane E E2 — Semantic execution metrics registry.
+     *
+     * <p>Provides in-memory counters for all semantic execution outcomes. Wired into
+     * {@link #queryExecutionService} so that every delegation attempt is observable
+     * via {@code GET /api/semantic/v1/execution/status}.
+     */
+    @Bean
+    public SemanticExecutionMetricsRegistry semanticExecutionMetricsRegistry() {
+        return new SemanticExecutionMetricsRegistry();
+    }
+
+    /**
+     * Lane E E1 — Semantic execution activation (DQR-002, Option 4).
+     *
+     * <p>Wires {@link SkadiServerQueryExecutionService} to delegate semantic query execution
+     * to skadi-server's {@code POST /api/v1/queries} endpoint. The JDBC credentials forwarded
+     * with each request are resolved from the datasource identified by
+     * {@code skadi.semantic.execution.datasource-id}.
+     *
+     * <p>If the configured datasource does not exist in {@code skadi.jdbc.datasources},
+     * empty strings are substituted and the execution service will report a connection error
+     * at runtime — server startup is not affected.
+     */
     @Bean
     public QueryExecutionService queryExecutionService(
             SemanticExecutionProperties execProps,
             SkadiJdbcProperties jdbcProps,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            SemanticExecutionMetricsRegistry metricsRegistry) {
 
         var datasource = jdbcProps.getDatasources().get(execProps.getDatasourceId());
         String jdbcUrl      = datasource != null ? datasource.getJdbcUrl()  : "";
@@ -125,6 +153,7 @@ public class SemanticContractConfiguration {
                 + "-> {} (datasource-id={})", execProps.getServerUrl(), execProps.getDatasourceId());
 
         return new SkadiServerQueryExecutionService(
-                execProps.getServerUrl(), jdbcUrl, jdbcUsername, jdbcPassword, objectMapper);
+                execProps.getServerUrl(), jdbcUrl, jdbcUsername, jdbcPassword,
+                objectMapper, metricsRegistry);
     }
 }

--- a/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticExecutionDiagnosticsController.java
+++ b/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticExecutionDiagnosticsController.java
@@ -1,0 +1,74 @@
+package org.iceforge.skadi.semantic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Read-only diagnostics endpoint for the Lane E semantic execution path (E2).
+ *
+ * <h2>Endpoint</h2>
+ * <pre>GET /api/semantic/v1/execution/status</pre>
+ *
+ * <p>Returns whether semantic execution is active, the configured server URL and
+ * datasource ID, and lifetime execution counters. Useful for confirming that the
+ * execution path is wired correctly and observing basic traffic patterns.
+ *
+ * <p>This endpoint does not execute queries, call Databricks, or modify any state.
+ * Counter values reset on server restart.
+ */
+@RestController
+@RequestMapping("/api/semantic/v1/execution")
+public class SemanticExecutionDiagnosticsController {
+
+    private final SemanticExecutionProperties execProps;
+    private final SemanticExecutionMetricsRegistry metricsRegistry;
+
+    public SemanticExecutionDiagnosticsController(
+            SemanticExecutionProperties execProps,
+            SemanticExecutionMetricsRegistry metricsRegistry) {
+        this.execProps       = execProps;
+        this.metricsRegistry = metricsRegistry;
+    }
+
+    /**
+     * Returns semantic execution activation status and lifetime counters.
+     *
+     * <p>Always returns HTTP 200. {@code active} is {@code true} whenever this
+     * endpoint is reachable — it confirms the execution path is wired into the
+     * server. The {@code serverUrl} and {@code datasourceId} fields show the
+     * configured delegation target (no credentials are exposed).
+     */
+    @GetMapping(value = "/status", produces = "application/json")
+    public ExecutionStatusResponse status() {
+        return new ExecutionStatusResponse(
+                true,
+                execProps.getServerUrl(),
+                execProps.getDatasourceId(),
+                new MetricsSnapshot(
+                        metricsRegistry.attempts(),
+                        metricsRegistry.cacheHits(),
+                        metricsRegistry.asyncAccepted(),
+                        metricsRegistry.successes(),
+                        metricsRegistry.failures(),
+                        metricsRegistry.timeouts(),
+                        metricsRegistry.errors()));
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ExecutionStatusResponse(
+            boolean active,
+            String serverUrl,
+            String datasourceId,
+            MetricsSnapshot metrics) {}
+
+    public record MetricsSnapshot(
+            long attempts,
+            long cacheHits,
+            long asyncAccepted,
+            long successes,
+            long failures,
+            long timeouts,
+            long errors) {}
+}

--- a/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticExecutionMetricsRegistry.java
+++ b/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticExecutionMetricsRegistry.java
@@ -1,0 +1,43 @@
+package org.iceforge.skadi.semantic;
+
+import org.iceforge.skadi.semantic.service.SemanticExecutionMetrics;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * In-memory counter registry for semantic execution observability (Lane E E2).
+ *
+ * <p>Implements {@link SemanticExecutionMetrics} using {@link LongAdder} counters
+ * and exposes snapshot values for the diagnostics endpoint. Thread-safe.
+ *
+ * <p>Counts reset on server restart. For persistent metrics, expose these values
+ * via Micrometer in a future observability story.
+ */
+@Component
+public class SemanticExecutionMetricsRegistry implements SemanticExecutionMetrics {
+
+    private final LongAdder attempts      = new LongAdder();
+    private final LongAdder cacheHits     = new LongAdder();
+    private final LongAdder asyncAccepted = new LongAdder();
+    private final LongAdder successes     = new LongAdder();
+    private final LongAdder failures      = new LongAdder();
+    private final LongAdder timeouts      = new LongAdder();
+    private final LongAdder errors        = new LongAdder();
+
+    @Override public void recordAttempt()       { attempts.increment(); }
+    @Override public void recordCacheHit()      { cacheHits.increment(); }
+    @Override public void recordAsyncAccepted() { asyncAccepted.increment(); }
+    @Override public void recordSuccess()       { successes.increment(); }
+    @Override public void recordFailure()       { failures.increment(); }
+    @Override public void recordTimeout()       { timeouts.increment(); }
+    @Override public void recordError()         { errors.increment(); }
+
+    public long attempts()      { return attempts.sum(); }
+    public long cacheHits()     { return cacheHits.sum(); }
+    public long asyncAccepted() { return asyncAccepted.sum(); }
+    public long successes()     { return successes.sum(); }
+    public long failures()      { return failures.sum(); }
+    public long timeouts()      { return timeouts.sum(); }
+    public long errors()        { return errors.sum(); }
+}

--- a/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionActivationTest.java
+++ b/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionActivationTest.java
@@ -49,7 +49,8 @@ class SemanticExecutionActivationTest {
         ds.setPassword("secret");
         jdbcProps.setDatasources(Map.of("default", ds));
 
-        QueryExecutionService svc = config.queryExecutionService(execProps, jdbcProps, new ObjectMapper());
+        QueryExecutionService svc = config.queryExecutionService(execProps, jdbcProps, new ObjectMapper(),
+                new SemanticExecutionMetricsRegistry());
 
         assertNotNull(svc);
         assertInstanceOf(SkadiServerQueryExecutionService.class, svc,
@@ -66,7 +67,8 @@ class SemanticExecutionActivationTest {
 
         var jdbcProps = new SkadiJdbcProperties(); // no datasources configured
 
-        QueryExecutionService svc = config.queryExecutionService(execProps, jdbcProps, new ObjectMapper());
+        QueryExecutionService svc = config.queryExecutionService(execProps, jdbcProps, new ObjectMapper(),
+                new SemanticExecutionMetricsRegistry());
 
         assertNotNull(svc, "bean must be created even when datasource is absent");
         assertInstanceOf(SkadiServerQueryExecutionService.class, svc);

--- a/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionDiagnosticsControllerTest.java
+++ b/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionDiagnosticsControllerTest.java
@@ -1,0 +1,114 @@
+package org.iceforge.skadi.semantic;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Unit tests for {@link SemanticExecutionDiagnosticsController}.
+ * Uses MockMvc standalone — no Spring context, no Databricks, no execution.
+ */
+class SemanticExecutionDiagnosticsControllerTest {
+
+    private static final String URL = "/api/semantic/v1/execution/status";
+
+    private MockMvc mockMvc;
+    private SemanticExecutionMetricsRegistry metricsRegistry;
+
+    @BeforeEach
+    void setUp() {
+        metricsRegistry = new SemanticExecutionMetricsRegistry();
+
+        var execProps = new SemanticExecutionProperties();
+        execProps.setServerUrl("http://skadi-server:8080");
+        execProps.setDatasourceId("prod-databricks");
+
+        var controller = new SemanticExecutionDiagnosticsController(execProps, metricsRegistry);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(controller)
+                .build();
+    }
+
+    // ── Status shape ──────────────────────────────────────────────────────────
+
+    @Test
+    void status_returnsHttp200() throws Exception {
+        mockMvc.perform(get(URL))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void status_activeIsTrue() throws Exception {
+        mockMvc.perform(get(URL))
+                .andExpect(jsonPath("$.active").value(true));
+    }
+
+    @Test
+    void status_exposesConfiguredServerUrl() throws Exception {
+        mockMvc.perform(get(URL))
+                .andExpect(jsonPath("$.serverUrl").value("http://skadi-server:8080"));
+    }
+
+    @Test
+    void status_exposesConfiguredDatasourceId() throws Exception {
+        mockMvc.perform(get(URL))
+                .andExpect(jsonPath("$.datasourceId").value("prod-databricks"));
+    }
+
+    // ── Metrics shape ─────────────────────────────────────────────────────────
+
+    @Test
+    void status_metricsStartAtZero() throws Exception {
+        mockMvc.perform(get(URL))
+                .andExpect(jsonPath("$.metrics.attempts").value(0))
+                .andExpect(jsonPath("$.metrics.cacheHits").value(0))
+                .andExpect(jsonPath("$.metrics.asyncAccepted").value(0))
+                .andExpect(jsonPath("$.metrics.successes").value(0))
+                .andExpect(jsonPath("$.metrics.failures").value(0))
+                .andExpect(jsonPath("$.metrics.timeouts").value(0))
+                .andExpect(jsonPath("$.metrics.errors").value(0));
+    }
+
+    @Test
+    void status_metricsReflectRecordedActivity() throws Exception {
+        metricsRegistry.recordAttempt();
+        metricsRegistry.recordAttempt();
+        metricsRegistry.recordCacheHit();
+        metricsRegistry.recordAttempt();
+        metricsRegistry.recordAsyncAccepted();
+        metricsRegistry.recordSuccess();
+
+        mockMvc.perform(get(URL))
+                .andExpect(jsonPath("$.metrics.attempts").value(3))
+                .andExpect(jsonPath("$.metrics.cacheHits").value(1))
+                .andExpect(jsonPath("$.metrics.asyncAccepted").value(1))
+                .andExpect(jsonPath("$.metrics.successes").value(1))
+                .andExpect(jsonPath("$.metrics.failures").value(0));
+    }
+
+    @Test
+    void status_failureCounterInResponse() throws Exception {
+        metricsRegistry.recordAttempt();
+        metricsRegistry.recordFailure();
+
+        mockMvc.perform(get(URL))
+                .andExpect(jsonPath("$.metrics.failures").value(1))
+                .andExpect(jsonPath("$.metrics.successes").value(0));
+    }
+
+    @Test
+    void status_timeoutAndErrorCounters() throws Exception {
+        metricsRegistry.recordTimeout();
+        metricsRegistry.recordError();
+
+        mockMvc.perform(get(URL))
+                .andExpect(jsonPath("$.metrics.timeouts").value(1))
+                .andExpect(jsonPath("$.metrics.errors").value(1));
+    }
+}

--- a/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionMetricsRegistryTest.java
+++ b/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionMetricsRegistryTest.java
@@ -1,0 +1,91 @@
+package org.iceforge.skadi.semantic;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link SemanticExecutionMetricsRegistry}.
+ * No Spring context — plain instantiation.
+ */
+class SemanticExecutionMetricsRegistryTest {
+
+    @Test
+    void counters_startAtZero() {
+        var reg = new SemanticExecutionMetricsRegistry();
+        assertEquals(0, reg.attempts());
+        assertEquals(0, reg.cacheHits());
+        assertEquals(0, reg.asyncAccepted());
+        assertEquals(0, reg.successes());
+        assertEquals(0, reg.failures());
+        assertEquals(0, reg.timeouts());
+        assertEquals(0, reg.errors());
+    }
+
+    @Test
+    void recordAttempt_incrementsAttempts() {
+        var reg = new SemanticExecutionMetricsRegistry();
+        reg.recordAttempt();
+        reg.recordAttempt();
+        assertEquals(2, reg.attempts());
+    }
+
+    @Test
+    void recordCacheHit_incrementsCacheHits() {
+        var reg = new SemanticExecutionMetricsRegistry();
+        reg.recordCacheHit();
+        assertEquals(1, reg.cacheHits());
+        assertEquals(0, reg.successes());
+    }
+
+    @Test
+    void recordAsyncAccepted_incrementsAsyncAccepted() {
+        var reg = new SemanticExecutionMetricsRegistry();
+        reg.recordAsyncAccepted();
+        assertEquals(1, reg.asyncAccepted());
+    }
+
+    @Test
+    void recordSuccess_incrementsSuccesses() {
+        var reg = new SemanticExecutionMetricsRegistry();
+        reg.recordSuccess();
+        assertEquals(1, reg.successes());
+        assertEquals(0, reg.failures());
+    }
+
+    @Test
+    void recordFailure_incrementsFailures() {
+        var reg = new SemanticExecutionMetricsRegistry();
+        reg.recordFailure();
+        assertEquals(1, reg.failures());
+        assertEquals(0, reg.successes());
+    }
+
+    @Test
+    void recordTimeout_incrementsTimeouts() {
+        var reg = new SemanticExecutionMetricsRegistry();
+        reg.recordTimeout();
+        assertEquals(1, reg.timeouts());
+    }
+
+    @Test
+    void recordError_incrementsErrors() {
+        var reg = new SemanticExecutionMetricsRegistry();
+        reg.recordError();
+        assertEquals(1, reg.errors());
+    }
+
+    @Test
+    void counters_areIndependent() {
+        var reg = new SemanticExecutionMetricsRegistry();
+        reg.recordAttempt();
+        reg.recordCacheHit();
+        assertEquals(1, reg.attempts());
+        assertEquals(1, reg.cacheHits());
+        assertEquals(0, reg.asyncAccepted());
+        assertEquals(0, reg.successes());
+        assertEquals(0, reg.failures());
+        assertEquals(0, reg.timeouts());
+        assertEquals(0, reg.errors());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds structured SLF4J logging to `SkadiServerQueryExecutionService` at every execution branch (attempt, cache-hit, async-accepted, poll-cycle, success, failure, timeout, error)
- Adds `SemanticExecutionMetrics` interface + `NoOpSemanticExecutionMetrics` in `skadi-semantic`; `SemanticExecutionMetricsRegistry` (`LongAdder` counters) in `skadi-server`
- Adds `GET /api/semantic/v1/execution/status` diagnostics endpoint — confirms execution is active, shows server URL + datasource ID, returns lifetime counter snapshot (no credentials exposed)
- `skadi-sql-gateway` untouched

## Depends on

PR #102 (issue #97) — Lane E E1 semantic execution activation

## What changed

**`skadi-semantic`** (plain Java, no Spring):
- `SemanticExecutionMetrics` interface — 7 outcome methods; exactly one terminal counter per `execute()` call
- `NoOpSemanticExecutionMetrics` — singleton no-op default
- `SkadiServerQueryExecutionService` — SLF4J logging on every path; metrics instrumented throughout; new 6-arg public constructor; null-safe error messages

**`skadi-server`**:
- `SemanticExecutionMetricsRegistry` — `@Component`, thread-safe `LongAdder` counters
- `SemanticExecutionDiagnosticsController` — `GET /api/semantic/v1/execution/status`
- `SemanticContractConfiguration` — new `semanticExecutionMetricsRegistry` bean; wired into `queryExecutionService`

## Test plan

- [x] `./mvnw verify -pl skadi-semantic,skadi-server -am` — 732 tests, all pass
- [x] `SemanticExecutionMetricsTest` (5) — capturing fake verifies correct counter per path
- [x] `SemanticExecutionMetricsRegistryTest` (9) — counter independence and increment correctness
- [x] `SemanticExecutionDiagnosticsControllerTest` (8) — MockMvc standalone; active flag, config fields, counter reflection
- [x] `skadi-sql-gateway` diff: 0 bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)