### PR TITLE
feat: add screen context semantic binding model (skadi#80)

### DIFF
--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -326,6 +326,29 @@ All D-lane issues closed. Committed directly to `main`.
 
 ---
 
+## Lane E1 — Semantic Metadata Foundation (Complete ✅)
+
+Stories #72–#82 (EPIC #82). Contract explanation metadata, ADR-012 fitness tests, and
+screen-context model — all committed to `main` as part of PR #94 (`ca87c72`).
+
+| Story | Description | Status | Issue |
+|---|---|---|---|
+| E1.1–E1.4 | Contract explanation metadata records | ✅ | #72–#75 |
+| E1.6 | Metadata API endpoints | ✅ | — |
+| E1.8 | Request validation endpoint | ✅ | — |
+| E1.9 | Screen-context and widget-binding model | ✅ | #80 |
+| E1.10 | ADR-012 fitness tests and guardrails | ✅ | #81 |
+
+Key model types (all in `org.iceforge.skadi.semantic.screen`):
+`DashboardScreenContext`, `WidgetSemanticBinding`, `BoundMeasure`, `BoundDimension`,
+`AppliedFilter`, `ContractBinding`, `UserEntitlementScope`, `ActiveWidgetContext`,
+`ExplainWidgetBindingRequest` — serializable model records only; no runtime, no LLM,
+no query execution, no SQL generation, `skadi-sql-gateway` untouched.
+
+Tests: `ScreenContextModelTest` (35), `Adr012FitnessTest` (21).
+
+---
+
 ## Lane E — Semantic Execution Activation (In Progress)
 
 | Story | Description | Status | Commit | Issue |


### PR DESCRIPTION
Closes #80

## What this PR contains

The screen-context and widget-binding explanation model (Lane E1.9) was already fully implemented and committed to `main` as part of PR #94. This PR records that completion in `ai/dev-status.md` and formally closes issue #80.

## Model types (all in `skadi-semantic`, `org.iceforge.skadi.semantic.screen`)

| Type | Purpose |
|---|---|
| `DashboardScreenContext` | Full screen state at the moment of a buddy-chat question |
| `WidgetSemanticBinding` | Contract, measures, dimensions, filters for one widget |
| `BoundMeasure` | A measure currently displayed in a widget |
| `BoundDimension` | A dimension used for grouping in a widget |
| `AppliedFilter` | A filter predicate constraining the widget's data |
| `ContractBinding` | Which contract and version powers a widget |
| `UserEntitlementScope` | Principal identity + entitlement-set placeholder |
| `ActiveWidgetContext` | Currently focused widget identity and type |
| `ExplainWidgetBindingRequest` | Input contract for a widget-explanation request |

## Guardrails respected

- Model / serializable API contract types only
- No buddy-chat runtime
- No LLM integration
- No UI runtime or dashboard layout engine
- No query execution
- No SQL generation
- `skadi-sql-gateway` untouched

## Tests

`ScreenContextModelTest` — 35 tests covering:
- construction and field access for all types
- required-field null/blank validation
- optional fields (null label, null entitlement set, null dashboard ID)
- defensive copies on list fields
- `DashboardScreenContext.activeWidgetBinding()` lookup (found / no active widget / no matching binding)
- JSON serialization — null fields omitted (`@JsonInclude(NON_NULL)`)
- Full `ExplainWidgetBindingRequest` JSON round-trip

`./mvnw test -pl skadi-semantic` — **529 tests, BUILD SUCCESS**