### PR TITLE
feat: Lane F F2 — semantic execution readiness diagnostics and operator runbook (skadi#112)

### DIFF
--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -1,9 +1,9 @@
 # Skadi — Development Status
 
 > Updated: 2026-05-17
-> Branch: `feature/110-semantic-execution-resilience`
-> Last commit: pending — Lane F F1: semantic execution circuit-breaker and resilience — skadi#110
-> Build: ✅ 760 tests passing (skadi-semantic: 549, skadi-server: 211; gateway unchanged)
+> Branch: `feature/112-semantic-execution-readiness-runbook`
+> Last commit: pending — Lane F F2: semantic execution readiness and operator runbook — skadi#112
+> Build: ✅ 768 tests passing (skadi-semantic: 556, skadi-server: 212; gateway unchanged)
 
 ---
 
@@ -359,8 +359,40 @@ Tests: `ScreenContextModelTest` (35), `Adr012FitnessTest` (21), `SemanticRequest
 | Story | Description | Status | Issue |
 |---|---|---|---|
 | F1 | Semantic execution health, readiness, and circuit-breaker behavior | ✅ | #110 |
+| F2 | Semantic execution readiness endpoint and operator runbook | ✅ | #112 |
 
 **Epic:** #109 — harden the Lane E semantic execution delegation path before buddy-chat, dashboard explanation, or gateway convergence depend on it.
+
+---
+
+## Lane F Completed — F2 Summary
+
+**Issue:** #112 | **Branch:** `feature/112-semantic-execution-readiness-runbook`
+
+**Lane F F2 scope:** Operational readiness classification and operator runbook for the semantic execution delegation path.
+
+### What was built in F2
+
+| Capability | Key Components | Module |
+|---|---|---|
+| Readiness enum | `SemanticExecutionReadiness` — `READY, DISABLED, DEGRADED, UNAVAILABLE`; `from(SemanticExecutionHealthStatus)` mapping | `skadi-semantic` |
+| Diagnostics field | `health.readiness` added to `GET /api/semantic/v1/execution/status` response | `skadi-server` |
+| Readiness tests | `SemanticExecutionReadinessTest` — 7 tests covering all 6 health-to-readiness mappings | `skadi-semantic` |
+| Operator runbook | `ai/lane-f/semantic-execution-readiness-runbook.md` — status interpretation, failure modes, config reference, deployment gate pattern | `ai/` |
+
+### Test count progression
+
+| Milestone | skadi-semantic | skadi-server | Total |
+|---|---|---|---|
+| F1 complete (baseline) | 549 | 211 | 760 |
+| F2 complete | 556 | 212 | 768 |
+
+### Lane F F2 non-goals (enforced throughout)
+
+- No `skadi-sql-gateway` changes
+- No LLM integration, UI runtime, or SQL generation
+- No full platform health framework
+- No secrets exposed in diagnostics
 
 ---
 

--- a/ai/lane-f/semantic-execution-readiness-runbook.md
+++ b/ai/lane-f/semantic-execution-readiness-runbook.md
@@ -1,0 +1,290 @@
+# Semantic Execution Readiness — Operator Runbook
+
+> Lane F F2 | Issue #112 | Covers `skadi-server` semantic execution delegation path only.
+> `skadi-sql-gateway` is unchanged and not referenced here.
+
+---
+
+## Purpose
+
+This runbook explains how to determine whether the semantic query execution delegation
+path is ready, how to interpret the diagnostics endpoint, and how to diagnose and
+recover from common failure modes.
+
+The semantic execution path delegates queries from `skadi-server` to its own
+`POST /api/v1/queries` endpoint via HTTP. It is guarded by a circuit breaker that
+limits the blast radius of server-side failures.
+
+---
+
+## Diagnostics Endpoint
+
+```
+GET /api/semantic/v1/execution/status
+```
+
+Returns a JSON snapshot of activation state, lifetime execution counters, and
+circuit-breaker health. This endpoint is read-only — it does not execute queries,
+contact Databricks, or modify any state.
+
+### Example response (healthy)
+
+```json
+{
+  "active": true,
+  "serverUrl": "http://skadi-server:8080",
+  "datasourceId": "prod-databricks",
+  "metrics": {
+    "attempts": 142,
+    "cacheHits": 98,
+    "asyncAccepted": 44,
+    "successes": 43,
+    "failures": 1,
+    "timeouts": 0,
+    "errors": 0
+  },
+  "health": {
+    "status": "HEALTHY",
+    "readiness": "READY",
+    "failureCount": 0,
+    "failureThreshold": 3,
+    "lastSuccessAt": "2026-05-17T22:48:00Z",
+    "lastFailureAt": "2026-05-17T20:13:00Z",
+    "lastFailureReason": "unexpected submit response: HTTP 503 state="
+  }
+}
+```
+
+### Example response (circuit open)
+
+```json
+{
+  "active": true,
+  "serverUrl": "http://skadi-server:8080",
+  "datasourceId": "prod-databricks",
+  "metrics": {
+    "attempts": 47,
+    "cacheHits": 0,
+    "asyncAccepted": 0,
+    "successes": 0,
+    "failures": 47,
+    "timeouts": 0,
+    "errors": 0
+  },
+  "health": {
+    "status": "CIRCUIT_OPEN",
+    "readiness": "DEGRADED",
+    "failureCount": 3,
+    "failureThreshold": 3,
+    "lastFailureAt": "2026-05-17T23:05:12Z",
+    "lastFailureReason": "Connection refused",
+    "circuitOpenUntil": "2026-05-17T23:05:42Z"
+  }
+}
+```
+
+---
+
+## Readiness Classification
+
+The `health.readiness` field provides a four-value operational classification derived
+from the raw `health.status`. Use `readiness` for dashboards, alerting, and deployment
+gates; use `status` for detailed diagnostics.
+
+| `health.status` | `health.readiness` | Meaning |
+|---|---|---|
+| `HEALTHY` | `READY` | Path is healthy; semantic queries will be delegated. |
+| `DISABLED` | `DISABLED` | Disabled by configuration; no calls are attempted. Not a fault. |
+| `CIRCUIT_OPEN` | `DEGRADED` | Circuit tripped after repeated failures; probe call pending after `circuitOpenUntil`. |
+| `UNAVAILABLE` | `UNAVAILABLE` | Server unreachable or returned an unexpected response. |
+| `TIMEOUT` | `UNAVAILABLE` | Server did not complete the query within the configured wait window. |
+| `FAILED` | `UNAVAILABLE` | Server returned a `FAILED` or `CANCELED` terminal state. |
+
+### Quick readiness decision tree
+
+```
+health.readiness == "READY"       → ✅ OK — delegation is active and healthy
+health.readiness == "DISABLED"    → ℹ️  By design — check skadi.semantic.execution.enabled
+health.readiness == "DEGRADED"    → ⚠️  Circuit open — see circuitOpenUntil; wait or investigate
+health.readiness == "UNAVAILABLE" → ❌  Needs attention — see failure mode section below
+```
+
+---
+
+## Configuration Reference
+
+```yaml
+skadi:
+  semantic:
+    execution:
+      enabled: true                          # false → DISABLED; no HTTP calls attempted
+      server-url: http://localhost:8080      # skadi-server base URL for POST /api/v1/queries
+      datasource-id: default                 # which skadi.jdbc.datasources entry to forward
+      circuit-breaker:
+        enabled: true                        # false → failures recorded but circuit never opens
+        failure-threshold: 3                 # consecutive failures before opening circuit
+        open-duration-ms: 30000              # ms the circuit stays open before probe (default: 30 s)
+```
+
+**Secrets note:** JDBC credentials (`jdbcUrl`, `username`, `password`) from the resolved
+datasource are forwarded to `skadi-server` in each request body but are **never** exposed
+in the diagnostics endpoint response. The `datasourceId` field is a logical identifier only.
+
+---
+
+## Common Failure Modes
+
+### 1. skadi-server is down
+
+**Symptoms:**
+- `health.status`: `UNAVAILABLE` → `CIRCUIT_OPEN` after threshold failures
+- `health.readiness`: `UNAVAILABLE` → `DEGRADED`
+- `health.lastFailureReason`: `Connection refused` or similar
+- `metrics.errors` incrementing
+
+**Resolution:**
+1. Check skadi-server process/pod is running and reachable at `serverUrl`.
+2. Once server is up, the circuit will self-heal after `open-duration-ms` expires —
+   a probe call will transition status back to `HEALTHY` on success.
+3. To confirm recovery: poll `GET /api/semantic/v1/execution/status` until
+   `health.readiness == "READY"`.
+
+---
+
+### 2. Bad base URL
+
+**Symptoms:**
+- `health.readiness`: `UNAVAILABLE`
+- `health.lastFailureReason`: `Connection refused` or DNS resolution failure
+- `serverUrl` in response does not match the running skadi-server address
+
+**Resolution:**
+1. Check `skadi.semantic.execution.server-url` in `application.yml`.
+2. Verify the URL is reachable from the server process: `curl <serverUrl>/actuator/health`.
+3. Fix the URL and restart `skadi-server`.
+
+---
+
+### 3. Timeout
+
+**Symptoms:**
+- `health.status`: `TIMEOUT`
+- `health.readiness`: `UNAVAILABLE`
+- `health.lastFailureReason`: `query timed out after Nms`
+- `metrics.timeouts` incrementing
+
+**Resolution:**
+1. Determine whether queries are taking longer than `open-duration-ms` to complete on
+   skadi-server (check skadi-server logs for query IDs from `metrics.asyncAccepted`).
+2. Increase `skadi.semantic.execution.circuit-breaker.open-duration-ms` if queries
+   legitimately require more time.
+3. Investigate slow Databricks SQL Warehouse utilization if queries are stalling.
+
+---
+
+### 4. Repeated failures causing circuit open
+
+**Symptoms:**
+- `health.status`: `CIRCUIT_OPEN`
+- `health.readiness`: `DEGRADED`
+- `health.failureCount` equals `health.failureThreshold`
+- `health.circuitOpenUntil` is a future timestamp
+- `active: true` but calls are short-circuited (no new HTTP requests until probe)
+
+**Behavior:**
+The circuit breaker automatically allows one probe call after `circuitOpenUntil` passes.
+- If the probe succeeds → `status: HEALTHY`, `readiness: READY`, `failureCount: 0`
+- If the probe fails → circuit re-opens for another `open-duration-ms` window
+
+**Resolution:**
+1. Identify the root cause from `health.lastFailureReason`.
+2. Fix the underlying issue (server down, bad config, slow queries).
+3. Wait for `circuitOpenUntil` to pass — the circuit self-heals without a restart.
+4. To verify recovery: `GET /api/semantic/v1/execution/status` → `readiness == "READY"`.
+5. If you need immediate recovery after fixing the root cause and don't want to wait:
+   restart `skadi-server` to reset circuit state (failure count resets to 0 on startup).
+
+---
+
+### 5. Recovery after server returns
+
+**Automatic recovery (recommended):**
+The circuit breaker self-heals. After `open-duration-ms` expires, a probe call is
+attempted. A successful probe resets failure count and restores `HEALTHY` status.
+No operator action required.
+
+**Verify recovery:**
+```bash
+# Poll until READY
+while true; do
+  STATUS=$(curl -s http://localhost:8080/api/semantic/v1/execution/status \
+    | jq -r '.health.readiness')
+  echo "$(date -u +%H:%M:%S) readiness=$STATUS"
+  [ "$STATUS" = "READY" ] && break
+  sleep 5
+done
+```
+
+**Manual reset (restart):**
+Restarting `skadi-server` resets all circuit-breaker state. Use only when the root
+cause is confirmed fixed and waiting for the probe window is not acceptable.
+
+---
+
+### 6. Semantic execution disabled by configuration
+
+**Symptoms:**
+- `active: false`
+- `health.status`: `DISABLED`
+- `health.readiness`: `DISABLED`
+- No metrics incrementing
+
+**This is not a fault.** `DISABLED` means `skadi.semantic.execution.enabled=false` was
+intentionally set. Semantic queries will return a `FAILED` result without any HTTP call.
+
+**To enable:** Set `skadi.semantic.execution.enabled=true` and restart `skadi-server`.
+
+---
+
+## Deployment Gate Pattern
+
+Use `readiness` to gate deployments or health checks:
+
+```bash
+READINESS=$(curl -s http://localhost:8080/api/semantic/v1/execution/status \
+  | jq -r '.health.readiness')
+
+case "$READINESS" in
+  READY)       echo "Semantic execution is ready"; exit 0 ;;
+  DISABLED)    echo "Semantic execution disabled (by config)"; exit 0 ;;
+  DEGRADED)    echo "Circuit open — check circuitOpenUntil"; exit 1 ;;
+  UNAVAILABLE) echo "Semantic execution unavailable — check lastFailureReason"; exit 1 ;;
+  *)           echo "Unknown readiness: $READINESS"; exit 1 ;;
+esac
+```
+
+---
+
+## Guardrails
+
+The following are **explicitly out of scope** for this runbook and for all Lane F work:
+
+- No SQL gateway convergence (DQR-004 remains open)
+- No `skadi-sql-gateway` changes
+- No buddy-chat runtime
+- No LLM integration
+- No SQL generation from semantic contracts
+- No UI runtime components
+- No secrets exposed in diagnostics (JDBC credentials are forwarded in request bodies
+  only and never appear in diagnostic responses)
+
+---
+
+## Related
+
+- F1 implementation: `SemanticExecutionCircuitBreaker`, `SemanticExecutionHealthStatus`, `SemanticExecutionHealthSnapshot`
+- F2 implementation: `SemanticExecutionReadiness`
+- Diagnostics endpoint: `SemanticExecutionDiagnosticsController`
+- Configuration: `SemanticExecutionProperties`
+- DQR-002: semantic execution delegation resolved (Option 4 — partial convergence)
+- DQR-004: full SQL gateway convergence (open; future scope)

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SemanticExecutionReadiness.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SemanticExecutionReadiness.java
@@ -1,0 +1,53 @@
+package org.iceforge.skadi.semantic.service;
+
+/**
+ * Operational readiness classification for the semantic execution delegation path.
+ *
+ * <p>Maps the fine-grained {@link SemanticExecutionHealthStatus} values to four
+ * operator-facing categories suitable for dashboards, alerting, and deployment gates.
+ *
+ * <table border="1">
+ *   <tr><th>Health status</th><th>Readiness</th><th>Meaning</th></tr>
+ *   <tr><td>HEALTHY</td><td>READY</td><td>Path is healthy; queries will be delegated.</td></tr>
+ *   <tr><td>DISABLED</td><td>DISABLED</td><td>Disabled by configuration; no calls attempted.</td></tr>
+ *   <tr><td>CIRCUIT_OPEN</td><td>DEGRADED</td><td>Circuit tripped; auto-probe pending.</td></tr>
+ *   <tr><td>UNAVAILABLE</td><td>UNAVAILABLE</td><td>Server unreachable or unexpected response.</td></tr>
+ *   <tr><td>TIMEOUT</td><td>UNAVAILABLE</td><td>Server did not respond within the wait window.</td></tr>
+ *   <tr><td>FAILED</td><td>UNAVAILABLE</td><td>Server returned a terminal failure state.</td></tr>
+ * </table>
+ */
+public enum SemanticExecutionReadiness {
+
+    /** Path is healthy; semantic query delegation will proceed normally. */
+    READY,
+
+    /** Delegation is disabled by configuration ({@code skadi.semantic.execution.enabled=false}). */
+    DISABLED,
+
+    /**
+     * Circuit breaker has tripped due to consecutive failures; calls are short-circuited
+     * until the open window expires and a probe call succeeds.
+     */
+    DEGRADED,
+
+    /**
+     * Server is unreachable, unresponsive, or returning errors; calls fail immediately.
+     * If the circuit breaker is enabled, repeated failures will transition to {@link #DEGRADED}.
+     */
+    UNAVAILABLE;
+
+    /**
+     * Maps a {@link SemanticExecutionHealthStatus} to its operational readiness classification.
+     *
+     * @param status the current health status from the circuit breaker
+     * @return the corresponding readiness category
+     */
+    public static SemanticExecutionReadiness from(SemanticExecutionHealthStatus status) {
+        return switch (status) {
+            case HEALTHY      -> READY;
+            case DISABLED     -> DISABLED;
+            case CIRCUIT_OPEN -> DEGRADED;
+            case UNAVAILABLE, TIMEOUT, FAILED -> UNAVAILABLE;
+        };
+    }
+}

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/SemanticExecutionReadinessTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/SemanticExecutionReadinessTest.java
@@ -1,0 +1,58 @@
+package org.iceforge.skadi.semantic.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that {@link SemanticExecutionReadiness#from(SemanticExecutionHealthStatus)}
+ * maps every health status to the correct operational readiness category.
+ */
+class SemanticExecutionReadinessTest {
+
+    @Test
+    void healthy_mapsTo_ready() {
+        assertEquals(SemanticExecutionReadiness.READY,
+                SemanticExecutionReadiness.from(SemanticExecutionHealthStatus.HEALTHY));
+    }
+
+    @Test
+    void disabled_mapsTo_disabled() {
+        assertEquals(SemanticExecutionReadiness.DISABLED,
+                SemanticExecutionReadiness.from(SemanticExecutionHealthStatus.DISABLED));
+    }
+
+    @Test
+    void circuitOpen_mapsTo_degraded() {
+        assertEquals(SemanticExecutionReadiness.DEGRADED,
+                SemanticExecutionReadiness.from(SemanticExecutionHealthStatus.CIRCUIT_OPEN));
+    }
+
+    @Test
+    void unavailable_mapsTo_unavailable() {
+        assertEquals(SemanticExecutionReadiness.UNAVAILABLE,
+                SemanticExecutionReadiness.from(SemanticExecutionHealthStatus.UNAVAILABLE));
+    }
+
+    @Test
+    void timeout_mapsTo_unavailable() {
+        assertEquals(SemanticExecutionReadiness.UNAVAILABLE,
+                SemanticExecutionReadiness.from(SemanticExecutionHealthStatus.TIMEOUT));
+    }
+
+    @Test
+    void failed_mapsTo_unavailable() {
+        assertEquals(SemanticExecutionReadiness.UNAVAILABLE,
+                SemanticExecutionReadiness.from(SemanticExecutionHealthStatus.FAILED));
+    }
+
+    @Test
+    void allStatusesCovered() {
+        // Ensures every enum constant has an explicit mapping (no switch fall-through)
+        for (SemanticExecutionHealthStatus status : SemanticExecutionHealthStatus.values()) {
+            SemanticExecutionReadiness result = SemanticExecutionReadiness.from(status);
+            org.junit.jupiter.api.Assertions.assertNotNull(result,
+                    "status " + status + " must map to a non-null readiness");
+        }
+    }
+}

--- a/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticExecutionDiagnosticsController.java
+++ b/skadi-server/src/main/java/org/iceforge/skadi/semantic/SemanticExecutionDiagnosticsController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import org.iceforge.skadi.semantic.service.SemanticExecutionCircuitBreaker;
 import org.iceforge.skadi.semantic.service.SemanticExecutionHealthSnapshot;
 import org.iceforge.skadi.semantic.service.SemanticExecutionHealthStatus;
+import org.iceforge.skadi.semantic.service.SemanticExecutionReadiness;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -57,6 +58,7 @@ public class SemanticExecutionDiagnosticsController {
                         metricsRegistry.errors()),
                 new HealthSnapshot(
                         snap.status().name(),
+                        SemanticExecutionReadiness.from(snap.status()).name(),
                         snap.failureCount(),
                         snap.failureThreshold(),
                         snap.lastSuccessAt(),
@@ -85,6 +87,7 @@ public class SemanticExecutionDiagnosticsController {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record HealthSnapshot(
             String status,
+            String readiness,
             int failureCount,
             int failureThreshold,
             Instant lastSuccessAt,

--- a/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionDiagnosticsControllerTest.java
+++ b/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionDiagnosticsControllerTest.java
@@ -125,6 +125,12 @@ class SemanticExecutionDiagnosticsControllerTest {
     }
 
     @Test
+    void status_healthReadinessIsReady() throws Exception {
+        mockMvc.perform(get(URL))
+                .andExpect(jsonPath("$.health.readiness").value("READY"));
+    }
+
+    @Test
     void status_healthFailureCountStartsAtZero() throws Exception {
         mockMvc.perform(get(URL))
                 .andExpect(jsonPath("$.health.failureCount").value(0));
@@ -158,7 +164,8 @@ class SemanticExecutionDiagnosticsControllerTest {
         mvc.perform(get(URL))
                 .andExpect(jsonPath("$.active").value(false))
                 .andExpect(jsonPath("$.health.status").value(
-                        SemanticExecutionHealthStatus.DISABLED.name()));
+                        SemanticExecutionHealthStatus.DISABLED.name()))
+                .andExpect(jsonPath("$.health.readiness").value("DISABLED"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `SemanticExecutionReadiness` enum — maps 6 health statuses to 4 operational categories: `READY`, `DISABLED`, `DEGRADED`, `UNAVAILABLE`
- Adds `health.readiness` field to `GET /api/semantic/v1/execution/status` response (alongside existing `health.status`); suitable for dashboards and deployment gates
- Adds operator runbook `ai/lane-f/semantic-execution-readiness-runbook.md` covering status interpretation, all 6 failure modes, config reference, recovery patterns, and a deployment gate shell snippet
- `skadi-sql-gateway` untouched (0 files changed in gateway module)

## Readiness mapping

| `health.status` | `health.readiness` |
|---|---|
| `HEALTHY` | `READY` |
| `DISABLED` | `DISABLED` |
| `CIRCUIT_OPEN` | `DEGRADED` |
| `UNAVAILABLE` | `UNAVAILABLE` |
| `TIMEOUT` | `UNAVAILABLE` |
| `FAILED` | `UNAVAILABLE` |

## Test plan

- [x] `./mvnw test -pl skadi-semantic` — 556 tests, 0 failures (`SemanticExecutionReadinessTest` 7 new tests)
- [x] `./mvnw test -pl skadi-server -am` — 212 tests, 0 failures (readiness field assertions added to `SemanticExecutionDiagnosticsControllerTest`)
- [x] Gateway guardrail: `git diff --name-only origin/main...HEAD | grep '^skadi-sql-gateway/'` → 0 files

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)