### PR TITLE
test: Lane F F3 — semantic execution resilience integration tests (skadi#114)

### DIFF
--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -1,9 +1,9 @@
 # Skadi — Development Status
 
 > Updated: 2026-05-17
-> Branch: `feature/112-semantic-execution-readiness-runbook`
-> Last commit: pending — Lane F F2: semantic execution readiness and operator runbook — skadi#112
-> Build: ✅ 768 tests passing (skadi-semantic: 556, skadi-server: 212; gateway unchanged)
+> Branch: `feature/114-semantic-execution-resilience-integration-tests`
+> Last commit: pending — Lane F F3: semantic execution resilience integration tests — skadi#114
+> Build: ✅ 787 tests passing (skadi-semantic: 556, skadi-server: 231; gateway unchanged)
 
 ---
 
@@ -360,8 +360,42 @@ Tests: `ScreenContextModelTest` (35), `Adr012FitnessTest` (21), `SemanticRequest
 |---|---|---|---|
 | F1 | Semantic execution health, readiness, and circuit-breaker behavior | ✅ | #110 |
 | F2 | Semantic execution readiness endpoint and operator runbook | ✅ | #112 |
+| F3 | Semantic execution resilience integration tests | ✅ | #114 |
 
 **Epic:** #109 — harden the Lane E semantic execution delegation path before buddy-chat, dashboard explanation, or gateway convergence depend on it.
+
+---
+
+## Lane F Completed — F3 Summary
+
+**Issue:** #114 | **Branch:** `feature/114-semantic-execution-resilience-integration-tests`
+
+**Lane F F3 scope:** Integration tests proving resilience, readiness, and diagnostics behavior through property binding, bean creation, and controller-level MockMvc assertions.
+
+### What was built in F3
+
+| Capability | Coverage | Module |
+|---|---|---|
+| Property binding | `Binder`-based tests verifying `skadi.semantic.execution.circuit-breaker.*` YAML binding (defaults, custom values, disabled flag) | `skadi-server` |
+| Bean creation | `SemanticContractConfiguration.semanticExecutionCircuitBreaker()` creates CB with correct threshold, URL, and disabled state | `skadi-server` |
+| Failure states in diagnostics | UNAVAILABLE, TIMEOUT, FAILED, CIRCUIT_OPEN → correct `readiness` field in response | `skadi-server` |
+| Full lifecycle | Failures → CIRCUIT_OPEN → clock-advanced probe → HEALTHY/READY recovery; probe failure re-opens | `skadi-server` |
+| Failure count | Increments correctly in diagnostics response across multiple `recordFailure` calls | `skadi-server` |
+| Secret safety | No `password`, `jdbcPassword`, `secret`, `token`, `credentials`, `jdbcUrl`, `username` in response | `skadi-server` |
+
+### Test count progression
+
+| Milestone | skadi-semantic | skadi-server | Total |
+|---|---|---|---|
+| F2 complete (baseline) | 556 | 212 | 768 |
+| F3 complete | 556 | 231 | 787 |
+
+### Lane F F3 non-goals (enforced throughout)
+
+- No `skadi-sql-gateway` changes
+- No real Databricks or network calls
+- No new API surface
+- No LLM integration, UI runtime, or SQL generation
 
 ---
 

--- a/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionResilienceIntegrationTest.java
+++ b/skadi-server/src/test/java/org/iceforge/skadi/semantic/SemanticExecutionResilienceIntegrationTest.java
@@ -1,0 +1,339 @@
+package org.iceforge.skadi.semantic;
+
+import org.iceforge.skadi.semantic.service.SemanticExecutionCircuitBreaker;
+import org.iceforge.skadi.semantic.service.SemanticExecutionHealthStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for Lane F semantic execution resilience, readiness, and diagnostics.
+ *
+ * <p>Covers the full diagnostics surface — property binding, bean creation, and
+ * end-to-end controller responses across healthy, failure, circuit-open, and
+ * recovery states.
+ *
+ * <p>No Spring context, no real network calls, no Databricks. Uses MockMvc standalone
+ * and injectable {@link Clock} for deterministic circuit-breaker state control.
+ */
+class SemanticExecutionResilienceIntegrationTest {
+
+    private static final String STATUS_URL = "/api/semantic/v1/execution/status";
+    private static final String SERVER_URL = "http://skadi-test:8080";
+    private static final int THRESHOLD = 3;
+    private static final long OPEN_MS = 1_000L;
+
+    // ── Property binding ──────────────────────────────────────────────────────
+
+    @Test
+    void properties_defaultValues_bindCorrectly() {
+        // Verify defaults without any YAML override
+        var props = new SemanticExecutionProperties();
+        assertTrue(props.isEnabled());
+        assertTrue(props.getCircuitBreaker().isEnabled());
+        assertEquals(3, props.getCircuitBreaker().getFailureThreshold());
+        assertEquals(30_000L, props.getCircuitBreaker().getOpenDurationMs());
+    }
+
+    @Test
+    void properties_customCircuitBreakerValues_bindFromYamlStyle() {
+        var source = new MapConfigurationPropertySource(Map.of(
+                "skadi.semantic.execution.enabled", "true",
+                "skadi.semantic.execution.server-url", "http://custom-server:9090",
+                "skadi.semantic.execution.datasource-id", "analytics-ds",
+                "skadi.semantic.execution.circuit-breaker.enabled", "true",
+                "skadi.semantic.execution.circuit-breaker.failure-threshold", "7",
+                "skadi.semantic.execution.circuit-breaker.open-duration-ms", "45000"
+        ));
+        var props = new Binder(source).bindOrCreate(
+                "skadi.semantic.execution", SemanticExecutionProperties.class);
+
+        assertTrue(props.isEnabled());
+        assertEquals("http://custom-server:9090", props.getServerUrl());
+        assertEquals("analytics-ds", props.getDatasourceId());
+        assertTrue(props.getCircuitBreaker().isEnabled());
+        assertEquals(7, props.getCircuitBreaker().getFailureThreshold());
+        assertEquals(45_000L, props.getCircuitBreaker().getOpenDurationMs());
+    }
+
+    @Test
+    void properties_executionDisabled_bindsCorrectly() {
+        var source = new MapConfigurationPropertySource(Map.of(
+                "skadi.semantic.execution.enabled", "false"
+        ));
+        var props = new Binder(source).bindOrCreate(
+                "skadi.semantic.execution", SemanticExecutionProperties.class);
+
+        assertFalse(props.isEnabled());
+    }
+
+    @Test
+    void properties_circuitBreakerDisabled_bindsCorrectly() {
+        var source = new MapConfigurationPropertySource(Map.of(
+                "skadi.semantic.execution.circuit-breaker.enabled", "false",
+                "skadi.semantic.execution.circuit-breaker.failure-threshold", "1",
+                "skadi.semantic.execution.circuit-breaker.open-duration-ms", "500"
+        ));
+        var props = new Binder(source).bindOrCreate(
+                "skadi.semantic.execution", SemanticExecutionProperties.class);
+
+        assertFalse(props.getCircuitBreaker().isEnabled());
+        assertEquals(1, props.getCircuitBreaker().getFailureThreshold());
+        assertEquals(500L, props.getCircuitBreaker().getOpenDurationMs());
+    }
+
+    // ── Bean creation from SemanticContractConfiguration ─────────────────────
+
+    @Test
+    void circuitBreakerBean_enabled_isHealthyByDefault() {
+        var config = new SemanticContractConfiguration();
+        var execProps = enabledExecProps();
+
+        var cb = config.semanticExecutionCircuitBreaker(execProps);
+
+        assertTrue(cb.isCallAllowed());
+        assertEquals(SemanticExecutionHealthStatus.HEALTHY, cb.snapshot().status());
+    }
+
+    @Test
+    void circuitBreakerBean_usesConfiguredThreshold() {
+        var config = new SemanticContractConfiguration();
+        var execProps = enabledExecProps();
+        execProps.getCircuitBreaker().setFailureThreshold(5);
+
+        var cb = config.semanticExecutionCircuitBreaker(execProps);
+
+        assertEquals(5, cb.snapshot().failureThreshold());
+    }
+
+    @Test
+    void circuitBreakerBean_executionDisabled_createsDisabledBreaker() {
+        var config = new SemanticContractConfiguration();
+        var execProps = new SemanticExecutionProperties();
+        execProps.setEnabled(false);
+        execProps.setServerUrl(SERVER_URL);
+
+        var cb = config.semanticExecutionCircuitBreaker(execProps);
+
+        assertFalse(cb.isCallAllowed());
+        assertEquals(SemanticExecutionHealthStatus.DISABLED, cb.snapshot().status());
+    }
+
+    @Test
+    void circuitBreakerBean_serverUrlExposedInSnapshot() {
+        var config = new SemanticContractConfiguration();
+        var execProps = enabledExecProps();
+        execProps.setServerUrl("http://specific-server:9999");
+
+        var cb = config.semanticExecutionCircuitBreaker(execProps);
+
+        assertEquals("http://specific-server:9999", cb.snapshot().skadiServerBaseUrl());
+    }
+
+    // ── Diagnostics: failure and circuit-open states ──────────────────────────
+
+    @Test
+    void diagnostics_afterSingleFailure_readinessIsUnavailable() throws Exception {
+        var cb = breaker(Clock.fixed(Instant.now(), ZoneOffset.UTC));
+        cb.recordFailure("server error", SemanticExecutionHealthStatus.UNAVAILABLE);
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.health.status").value("UNAVAILABLE"))
+                .andExpect(jsonPath("$.health.readiness").value("UNAVAILABLE"))
+                .andExpect(jsonPath("$.health.failureCount").value(1))
+                .andExpect(jsonPath("$.active").value(true));
+    }
+
+    @Test
+    void diagnostics_timeout_readinessIsUnavailable() throws Exception {
+        var cb = breaker(Clock.fixed(Instant.now(), ZoneOffset.UTC));
+        cb.recordFailure("query timed out after 300000ms", SemanticExecutionHealthStatus.TIMEOUT);
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.health.status").value("TIMEOUT"))
+                .andExpect(jsonPath("$.health.readiness").value("UNAVAILABLE"))
+                .andExpect(jsonPath("$.active").value(true));
+    }
+
+    @Test
+    void diagnostics_serverFailedState_readinessIsUnavailable() throws Exception {
+        var cb = breaker(Clock.fixed(Instant.now(), ZoneOffset.UTC));
+        cb.recordFailure("query failed on server", SemanticExecutionHealthStatus.FAILED);
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.health.status").value("FAILED"))
+                .andExpect(jsonPath("$.health.readiness").value("UNAVAILABLE"));
+    }
+
+    @Test
+    void diagnostics_afterThresholdFailures_circuitOpenAndDegraded() throws Exception {
+        var cb = breaker(Clock.fixed(Instant.now(), ZoneOffset.UTC));
+        for (int i = 0; i < THRESHOLD; i++) {
+            cb.recordFailure("connection refused", SemanticExecutionHealthStatus.UNAVAILABLE);
+        }
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.health.status").value("CIRCUIT_OPEN"))
+                .andExpect(jsonPath("$.health.readiness").value("DEGRADED"))
+                .andExpect(jsonPath("$.health.failureCount").value(THRESHOLD))
+                .andExpect(jsonPath("$.health.failureThreshold").value(THRESHOLD))
+                .andExpect(jsonPath("$.active").value(true));
+    }
+
+    @Test
+    void diagnostics_circuitOpen_exposesOpenUntilTimestamp() throws Exception {
+        var cb = breaker(Clock.fixed(Instant.now(), ZoneOffset.UTC));
+        for (int i = 0; i < THRESHOLD; i++) {
+            cb.recordFailure("err", SemanticExecutionHealthStatus.UNAVAILABLE);
+        }
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.health.circuitOpenUntil").isNotEmpty());
+    }
+
+    @Test
+    void diagnostics_failureCount_incrementsInResponse() throws Exception {
+        var cb = breaker(Clock.fixed(Instant.now(), ZoneOffset.UTC));
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.health.failureCount").value(0));
+
+        cb.recordFailure("err", SemanticExecutionHealthStatus.UNAVAILABLE);
+        cb.recordFailure("err", SemanticExecutionHealthStatus.UNAVAILABLE);
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.health.failureCount").value(2));
+    }
+
+    @Test
+    void diagnostics_lastFailureReasonExposed() throws Exception {
+        var cb = breaker(Clock.fixed(Instant.now(), ZoneOffset.UTC));
+        cb.recordFailure("Connection refused to http://skadi-test:8080", SemanticExecutionHealthStatus.UNAVAILABLE);
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.health.lastFailureReason")
+                        .value("Connection refused to http://skadi-test:8080"));
+    }
+
+    // ── Diagnostics: full lifecycle (failures → circuit open → probe → recovery) ──
+
+    @Test
+    void diagnostics_probeAfterWindowExpiry_resetsToHealthyAndReady() throws Exception {
+        Instant base = Instant.parse("2026-05-17T10:00:00Z");
+        Instant[] now = {base};
+        Clock clock = new Clock() {
+            @Override public ZoneOffset getZone() { return ZoneOffset.UTC; }
+            @Override public Clock withZone(java.time.ZoneId zone) { return this; }
+            @Override public Instant instant() { return now[0]; }
+        };
+
+        var cb = new SemanticExecutionCircuitBreaker(true, THRESHOLD, OPEN_MS, SERVER_URL, clock);
+
+        // Trip the circuit
+        for (int i = 0; i < THRESHOLD; i++) {
+            cb.recordFailure("server down", SemanticExecutionHealthStatus.UNAVAILABLE);
+        }
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.health.readiness").value("DEGRADED"));
+
+        // Advance past open window and allow probe
+        now[0] = base.plusMillis(OPEN_MS + 1);
+        cb.isCallAllowed(); // probe call — transitions to HEALTHY
+        cb.recordSuccess(); // probe succeeds
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.health.status").value("HEALTHY"))
+                .andExpect(jsonPath("$.health.readiness").value("READY"))
+                .andExpect(jsonPath("$.health.failureCount").value(0))
+                .andExpect(jsonPath("$.health.circuitOpenUntil").doesNotExist());
+    }
+
+    @Test
+    void diagnostics_probeFailure_reOpensCircuit() throws Exception {
+        Instant base = Instant.parse("2026-05-17T10:00:00Z");
+        Instant[] now = {base};
+        Clock clock = new Clock() {
+            @Override public ZoneOffset getZone() { return ZoneOffset.UTC; }
+            @Override public Clock withZone(java.time.ZoneId zone) { return this; }
+            @Override public Instant instant() { return now[0]; }
+        };
+
+        var cb = new SemanticExecutionCircuitBreaker(true, THRESHOLD, OPEN_MS, SERVER_URL, clock);
+        for (int i = 0; i < THRESHOLD; i++) {
+            cb.recordFailure("err", SemanticExecutionHealthStatus.UNAVAILABLE);
+        }
+
+        // Probe window expires and probe fails
+        now[0] = base.plusMillis(OPEN_MS + 1);
+        cb.isCallAllowed(); // probe → HEALTHY temporarily
+        cb.recordFailure("still down", SemanticExecutionHealthStatus.UNAVAILABLE);
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.health.status").value("CIRCUIT_OPEN"))
+                .andExpect(jsonPath("$.health.readiness").value("DEGRADED"))
+                .andExpect(jsonPath("$.health.circuitOpenUntil").isNotEmpty());
+    }
+
+    // ── Diagnostics: secret safety ────────────────────────────────────────────
+
+    @Test
+    void diagnostics_noSecretsInResponse() throws Exception {
+        var cb = breaker(Clock.fixed(Instant.now(), ZoneOffset.UTC));
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andExpect(jsonPath("$.jdbcPassword").doesNotExist())
+                .andExpect(jsonPath("$.secret").doesNotExist())
+                .andExpect(jsonPath("$.token").doesNotExist())
+                .andExpect(jsonPath("$.credentials").doesNotExist());
+    }
+
+    @Test
+    void diagnostics_serverUrlExposed_datasourceIdExposed_noCredentials() throws Exception {
+        var cb = breaker(Clock.fixed(Instant.now(), ZoneOffset.UTC));
+
+        mvc(cb).perform(get(STATUS_URL))
+                .andExpect(jsonPath("$.serverUrl").value(SERVER_URL))
+                .andExpect(jsonPath("$.datasourceId").value("test-ds"))
+                .andExpect(jsonPath("$.jdbcUrl").doesNotExist())
+                .andExpect(jsonPath("$.username").doesNotExist());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static SemanticExecutionCircuitBreaker breaker(Clock clock) {
+        return new SemanticExecutionCircuitBreaker(true, THRESHOLD, OPEN_MS, SERVER_URL, clock);
+    }
+
+    private static SemanticExecutionProperties enabledExecProps() {
+        var props = new SemanticExecutionProperties();
+        props.setEnabled(true);
+        props.setServerUrl(SERVER_URL);
+        return props;
+    }
+
+    private static MockMvc mvc(SemanticExecutionCircuitBreaker cb) {
+        var execProps = new SemanticExecutionProperties();
+        execProps.setServerUrl(SERVER_URL);
+        execProps.setDatasourceId("test-ds");
+
+        var controller = new SemanticExecutionDiagnosticsController(
+                execProps, new SemanticExecutionMetricsRegistry(), cb);
+        return MockMvcBuilders.standaloneSetup(controller).build();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SemanticExecutionResilienceIntegrationTest` — 19 focused integration tests covering the full Lane F resilience surface
- Property binding: `Binder`-based tests verify `skadi.semantic.execution.circuit-breaker.*` YAML properties bind correctly (defaults, custom values, disabled flag)
- Bean creation: `SemanticContractConfiguration.semanticExecutionCircuitBreaker()` creates CB with correct threshold, URL, and disabled state from properties
- Failure states: UNAVAILABLE / TIMEOUT / FAILED / CIRCUIT_OPEN → correct `health.readiness` in diagnostics response
- Full lifecycle: failures → CIRCUIT_OPEN → clock-advanced probe → HEALTHY/READY recovery; probe failure re-opens circuit
- Secret safety: confirms no password/credentials/jdbcUrl/username fields appear in the diagnostics response
- `skadi-sql-gateway`: 0 files changed

## Test plan

- [x] `./mvnw test -pl skadi-semantic` — 556 tests, 0 failures
- [x] `./mvnw test -pl skadi-server -am` — 231 tests, 0 failures (19 new in `SemanticExecutionResilienceIntegrationTest`)
- [x] Gateway guardrail: `git diff --name-only origin/main...HEAD | grep '^skadi-sql-gateway/'` → 0 files
- [x] No real Databricks, no real network calls, no Spring full-context required

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)