### PR TITLE
feat: Lane F F4 — semantic execution failure classification and safe error responses (skadi#117)

### DIFF
--- a/ai/dev-status.md
+++ b/ai/dev-status.md
@@ -1,9 +1,9 @@
 # Skadi — Development Status
 
-> Updated: 2026-05-17
-> Branch: `feature/114-semantic-execution-resilience-integration-tests`
-> Last commit: pending — Lane F F3: semantic execution resilience integration tests — skadi#114
-> Build: ✅ 787 tests passing (skadi-semantic: 556, skadi-server: 231; gateway unchanged)
+> Updated: 2026-05-18
+> Branch: `feature/117-semantic-execution-failure-classification`
+> Last commit: pending — Lane F F4: semantic execution failure classification — skadi#117
+> Build: ✅ 805 tests passing (skadi-semantic: 574, skadi-server: 231; gateway unchanged)
 
 ---
 
@@ -361,8 +361,40 @@ Tests: `ScreenContextModelTest` (35), `Adr012FitnessTest` (21), `SemanticRequest
 | F1 | Semantic execution health, readiness, and circuit-breaker behavior | ✅ | #110 |
 | F2 | Semantic execution readiness endpoint and operator runbook | ✅ | #112 |
 | F3 | Semantic execution resilience integration tests | ✅ | #114 |
+| F4 | Semantic execution failure classification and operator-safe error responses | ✅ | #117 |
 
 **Epic:** #109 — harden the Lane E semantic execution delegation path before buddy-chat, dashboard explanation, or gateway convergence depend on it.
+
+---
+
+## Lane F Completed — F4 Summary
+
+**Issue:** #117 | **Branch:** `feature/117-semantic-execution-failure-classification`
+
+**Lane F F4 scope:** Structured failure classification ensuring every failure path in `SkadiServerQueryExecutionService` returns a stable, secret-free message. Raw exception details remain in structured logs only.
+
+### What was built in F4
+
+| Capability | Key Components | Module |
+|---|---|---|
+| Failure enum | `SemanticExecutionFailure` — 6 values: `DISABLED, CIRCUIT_OPEN, UNAVAILABLE, TIMEOUT, REMOTE_ERROR, UNEXPECTED`; `safeMessage()` and `fromHealthStatus()` methods | `skadi-semantic` |
+| Safe error messages | All 7 failure paths in `SkadiServerQueryExecutionService` updated to return `SemanticExecutionFailure.X.safeMessage()` instead of raw exception messages | `skadi-semantic` |
+| Secret-free CB reasons | `circuitBreaker.recordFailure(reason, ...)` now uses safe messages; raw exception details logged only | `skadi-semantic` |
+| Classification tests | `SemanticExecutionFailureClassificationTest` — 18 tests covering enum values, `fromHealthStatus` mapping, all 6 failure paths, secret-leak prevention, and success path unchanged | `skadi-semantic` |
+
+### Test count progression
+
+| Milestone | skadi-semantic | skadi-server | Total |
+|---|---|---|---|
+| F3 complete (baseline) | 556 | 231 | 787 |
+| F4 complete | 574 | 231 | 805 |
+
+### Lane F F4 non-goals (enforced throughout)
+
+- No `skadi-sql-gateway` changes
+- No SQL generation, LLM, or UI runtime
+- No redesign of `QueryExecutionService`
+- Success path behavior unchanged
 
 ---
 

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SemanticExecutionFailure.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SemanticExecutionFailure.java
@@ -1,0 +1,69 @@
+package org.iceforge.skadi.semantic.service;
+
+/**
+ * Classifies semantic execution delegation failures into stable, operator-safe categories.
+ *
+ * <p>Each value carries a {@link #safeMessage()} that is:
+ * <ul>
+ *   <li>stable — the string does not change between invocations for the same failure type</li>
+ *   <li>safe — contains no secrets, JDBC URLs, credentials, raw exception text, or stack traces</li>
+ *   <li>operator-readable — meaningful to a platform operator without internal implementation detail</li>
+ * </ul>
+ *
+ * <p>Raw exception details, HTTP status codes, and server-side error messages are logged
+ * at WARN/ERROR level for operator diagnosis but are never propagated to callers or stored
+ * in the circuit-breaker reason that appears in diagnostics responses.
+ *
+ * <p>Use {@link #fromHealthStatus(SemanticExecutionHealthStatus)} to derive the failure
+ * classification from a circuit-breaker status at pre-call check time.
+ */
+public enum SemanticExecutionFailure {
+
+    /** Delegation is disabled by configuration. No HTTP calls were attempted. */
+    DISABLED,
+
+    /** Circuit breaker tripped; calls are paused until the open window expires and a probe succeeds. */
+    CIRCUIT_OPEN,
+
+    /** Remote server was unreachable, returned an unexpected response, or refused the connection. */
+    UNAVAILABLE,
+
+    /** Delegation timed out before the remote server returned a terminal state. */
+    TIMEOUT,
+
+    /** Remote server accepted the query but returned a FAILED or CANCELED terminal state. */
+    REMOTE_ERROR,
+
+    /** An unexpected exception occurred during delegation. Details in structured logs only. */
+    UNEXPECTED;
+
+    /**
+     * Returns a stable, operator-safe failure message.
+     * Contains no secrets, exception class names, stack traces, JDBC URLs, or credentials.
+     */
+    public String safeMessage() {
+        return switch (this) {
+            case DISABLED     -> "semantic execution is disabled";
+            case CIRCUIT_OPEN -> "semantic execution circuit is open";
+            case UNAVAILABLE  -> "semantic execution server is unavailable";
+            case TIMEOUT      -> "semantic execution timed out";
+            case REMOTE_ERROR -> "remote server reported a query failure";
+            case UNEXPECTED   -> "semantic execution failed unexpectedly";
+        };
+    }
+
+    /**
+     * Derives the failure classification from a circuit-breaker health status.
+     * Used on the pre-call path when {@link SemanticExecutionCircuitBreaker#isCallAllowed()} returns false.
+     *
+     * @param status the current CB health status
+     * @return the corresponding failure classification
+     */
+    public static SemanticExecutionFailure fromHealthStatus(SemanticExecutionHealthStatus status) {
+        return switch (status) {
+            case DISABLED     -> DISABLED;
+            case CIRCUIT_OPEN -> CIRCUIT_OPEN;
+            default           -> UNAVAILABLE;
+        };
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SkadiServerQueryExecutionService.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/service/SkadiServerQueryExecutionService.java
@@ -156,14 +156,14 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
 
         if (!circuitBreaker.isCallAllowed()) {
             SemanticExecutionHealthStatus cbStatus = circuitBreaker.snapshot().status();
+            SemanticExecutionFailure failure = SemanticExecutionFailure.fromHealthStatus(cbStatus);
             if (cbStatus == SemanticExecutionHealthStatus.DISABLED) {
                 log.debug("semantic-exec: disabled principal={}", principal);
             } else {
                 log.warn("semantic-exec: circuit-open principal={}", principal);
             }
             metrics.recordFailure();
-            return QueryExecutionResult.failed(request.context(), identity,
-                    "semantic execution unavailable: " + cbStatus.name().toLowerCase().replace('_', ' '));
+            return QueryExecutionResult.failed(request.context(), identity, failure.safeMessage());
         }
 
         try {
@@ -193,26 +193,30 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
                 return pollUntilDone(request.context(), identity, queryId);
             }
 
-            String msg = "unexpected submit response: HTTP " + response.statusCode() + " state=" + state;
             log.warn("semantic-exec: unexpected-submit-response http={} state={} principal={}",
                     response.statusCode(), state, principal);
-            circuitBreaker.recordFailure(msg, SemanticExecutionHealthStatus.UNAVAILABLE);
+            circuitBreaker.recordFailure(SemanticExecutionFailure.UNAVAILABLE.safeMessage(),
+                    SemanticExecutionHealthStatus.UNAVAILABLE);
             metrics.recordFailure();
-            return QueryExecutionResult.failed(request.context(), identity, msg);
+            return QueryExecutionResult.failed(request.context(), identity,
+                    SemanticExecutionFailure.UNAVAILABLE.safeMessage());
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            String msg = "interrupted while waiting for query: " + e.getMessage();
             log.warn("semantic-exec: interrupted principal={}", principal);
-            circuitBreaker.recordFailure(msg, SemanticExecutionHealthStatus.TIMEOUT);
+            circuitBreaker.recordFailure(SemanticExecutionFailure.TIMEOUT.safeMessage(),
+                    SemanticExecutionHealthStatus.TIMEOUT);
             metrics.recordError();
-            return QueryExecutionResult.failed(request.context(), identity, msg);
+            return QueryExecutionResult.failed(request.context(), identity,
+                    SemanticExecutionFailure.TIMEOUT.safeMessage());
         } catch (Exception e) {
-            String msg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-            log.error("semantic-exec: error principal={} msg={}", principal, msg, e);
-            circuitBreaker.recordFailure(msg, SemanticExecutionHealthStatus.UNAVAILABLE);
+            // Log the raw exception for operator diagnosis; never propagate it to callers.
+            log.error("semantic-exec: error principal={}", principal, e);
+            circuitBreaker.recordFailure(SemanticExecutionFailure.UNEXPECTED.safeMessage(),
+                    SemanticExecutionHealthStatus.UNAVAILABLE);
             metrics.recordError();
-            return QueryExecutionResult.failed(request.context(), identity, msg);
+            return QueryExecutionResult.failed(request.context(), identity,
+                    SemanticExecutionFailure.UNEXPECTED.safeMessage());
         }
     }
 
@@ -256,26 +260,30 @@ public final class SkadiServerQueryExecutionService implements QueryExecutionSer
                 return QueryExecutionResult.completed(ctx, identity, CacheEntryState.ABSENT);
             }
             if ("FAILED".equals(state)) {
-                String msg = statusNode.path("message").asText("query failed on server");
-                log.warn("semantic-exec: failed queryId={} msg={}", queryId, msg);
-                circuitBreaker.recordFailure(msg, SemanticExecutionHealthStatus.FAILED);
+                // Log raw server message for operator diagnosis; return stable safe message to caller.
+                String rawMsg = statusNode.path("message").asText("query failed on server");
+                log.warn("semantic-exec: failed queryId={} msg={}", queryId, rawMsg);
+                circuitBreaker.recordFailure(SemanticExecutionFailure.REMOTE_ERROR.safeMessage(),
+                        SemanticExecutionHealthStatus.FAILED);
                 metrics.recordFailure();
-                return QueryExecutionResult.failed(ctx, identity, msg);
+                return QueryExecutionResult.failed(ctx, identity,
+                        SemanticExecutionFailure.REMOTE_ERROR.safeMessage());
             }
             if ("CANCELED".equals(state)) {
-                String msg = "query was canceled on server";
                 log.warn("semantic-exec: canceled queryId={}", queryId);
-                circuitBreaker.recordFailure(msg, SemanticExecutionHealthStatus.FAILED);
+                circuitBreaker.recordFailure(SemanticExecutionFailure.REMOTE_ERROR.safeMessage(),
+                        SemanticExecutionHealthStatus.FAILED);
                 metrics.recordFailure();
-                return QueryExecutionResult.failed(ctx, identity, msg);
+                return QueryExecutionResult.failed(ctx, identity,
+                        SemanticExecutionFailure.REMOTE_ERROR.safeMessage());
             }
             // QUEUED or RUNNING — keep polling
         }
 
-        String msg = "query timed out after " + maxWaitMs + "ms";
         log.warn("semantic-exec: timeout queryId={} maxWaitMs={}", queryId, maxWaitMs);
-        circuitBreaker.recordFailure(msg, SemanticExecutionHealthStatus.TIMEOUT);
+        circuitBreaker.recordFailure(SemanticExecutionFailure.TIMEOUT.safeMessage(),
+                SemanticExecutionHealthStatus.TIMEOUT);
         metrics.recordTimeout();
-        return QueryExecutionResult.failed(ctx, identity, msg);
+        return QueryExecutionResult.failed(ctx, identity, SemanticExecutionFailure.TIMEOUT.safeMessage());
     }
 }

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/SemanticExecutionFailureClassificationTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/service/SemanticExecutionFailureClassificationTest.java
@@ -1,0 +1,343 @@
+package org.iceforge.skadi.semantic.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.iceforge.skadi.semantic.cache.CacheContract;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.time.Clock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link SemanticExecutionFailure} classification and
+ * the corresponding safe message behavior in {@link SkadiServerQueryExecutionService}.
+ *
+ * <p>Verifies that every failure path returns a stable, secret-free message
+ * and that raw exception details do not propagate to callers.
+ *
+ * <p>No Spring context, no Databricks. Uses lightweight JDK HttpServer fakes
+ * and direct circuit-breaker state setup.
+ */
+class SemanticExecutionFailureClassificationTest {
+
+    private static final String SERVER_URL = "http://localhost:1"; // unreachable
+    private static final ExecutionContext CTX = ExecutionContext.of("alice");
+    private static final String SQL = "SELECT 1 FROM dual";
+
+    // Credential-like keywords that must never appear in safe messages or returned results
+    private static final String[] FORBIDDEN_KEYWORDS = {
+            "jdbc:", "password", "secret", "token", "credential",
+            "Exception", "stack", "Caused by", "at org.", "at java."
+    };
+
+    // ── SemanticExecutionFailure enum ─────────────────────────────────────────
+
+    @Test
+    void allFailures_haveNonBlankSafeMessage() {
+        for (SemanticExecutionFailure f : SemanticExecutionFailure.values()) {
+            String msg = f.safeMessage();
+            assertNotNull(msg, f + ".safeMessage() must not be null");
+            assertFalse(msg.isBlank(), f + ".safeMessage() must not be blank");
+        }
+    }
+
+    @Test
+    void safeMessages_containNoForbiddenKeywords() {
+        for (SemanticExecutionFailure f : SemanticExecutionFailure.values()) {
+            String msg = f.safeMessage().toLowerCase();
+            for (String keyword : FORBIDDEN_KEYWORDS) {
+                assertFalse(msg.contains(keyword.toLowerCase()),
+                        f + ".safeMessage() must not contain '" + keyword + "'");
+            }
+        }
+    }
+
+    @Test
+    void fromHealthStatus_disabled_returnsDisabled() {
+        assertEquals(SemanticExecutionFailure.DISABLED,
+                SemanticExecutionFailure.fromHealthStatus(SemanticExecutionHealthStatus.DISABLED));
+    }
+
+    @Test
+    void fromHealthStatus_circuitOpen_returnsCircuitOpen() {
+        assertEquals(SemanticExecutionFailure.CIRCUIT_OPEN,
+                SemanticExecutionFailure.fromHealthStatus(SemanticExecutionHealthStatus.CIRCUIT_OPEN));
+    }
+
+    @Test
+    void fromHealthStatus_healthy_returnsUnavailable() {
+        assertEquals(SemanticExecutionFailure.UNAVAILABLE,
+                SemanticExecutionFailure.fromHealthStatus(SemanticExecutionHealthStatus.HEALTHY));
+    }
+
+    @Test
+    void fromHealthStatus_unavailable_returnsUnavailable() {
+        assertEquals(SemanticExecutionFailure.UNAVAILABLE,
+                SemanticExecutionFailure.fromHealthStatus(SemanticExecutionHealthStatus.UNAVAILABLE));
+    }
+
+    @Test
+    void fromHealthStatus_timeout_returnsUnavailable() {
+        assertEquals(SemanticExecutionFailure.UNAVAILABLE,
+                SemanticExecutionFailure.fromHealthStatus(SemanticExecutionHealthStatus.TIMEOUT));
+    }
+
+    @Test
+    void fromHealthStatus_failed_returnsUnavailable() {
+        assertEquals(SemanticExecutionFailure.UNAVAILABLE,
+                SemanticExecutionFailure.fromHealthStatus(SemanticExecutionHealthStatus.FAILED));
+    }
+
+    // ── Execute: disabled path ────────────────────────────────────────────────
+
+    @Test
+    void execute_disabled_returnsDisabledSafeMessage() {
+        var cb = SemanticExecutionCircuitBreaker.disabled(SERVER_URL);
+        var svc = service(SERVER_URL, cb);
+
+        var result = svc.execute(request());
+
+        assertEquals(ExecutionStatus.FAILED, result.status());
+        assertEquals(SemanticExecutionFailure.DISABLED.safeMessage(), result.errorMessage());
+        assertNoForbiddenKeywords(result.errorMessage());
+    }
+
+    // ── Execute: circuit-open path ────────────────────────────────────────────
+
+    @Test
+    void execute_circuitOpen_returnsCircuitOpenSafeMessage() {
+        var cb = new SemanticExecutionCircuitBreaker(true, 1, 60_000L, SERVER_URL, Clock.systemUTC());
+        cb.recordFailure("err", SemanticExecutionHealthStatus.UNAVAILABLE); // trips circuit at threshold=1
+
+        var svc = service(SERVER_URL, cb);
+
+        var result = svc.execute(request());
+
+        assertEquals(ExecutionStatus.FAILED, result.status());
+        assertEquals(SemanticExecutionFailure.CIRCUIT_OPEN.safeMessage(), result.errorMessage());
+        assertNoForbiddenKeywords(result.errorMessage());
+    }
+
+    // ── Execute: connection refused (UNEXPECTED) ──────────────────────────────
+
+    @Test
+    void execute_connectionRefused_returnsUnexpectedSafeMessage() {
+        var cb = SemanticExecutionCircuitBreaker.alwaysAllow(SERVER_URL);
+        var svc = service(SERVER_URL, cb); // port 1 is unreachable
+
+        var result = svc.execute(request());
+
+        assertEquals(ExecutionStatus.FAILED, result.status());
+        assertEquals(SemanticExecutionFailure.UNEXPECTED.safeMessage(), result.errorMessage());
+        // Critical: raw exception message (which could contain JDBC URL/credentials) must NOT appear
+        assertNoForbiddenKeywords(result.errorMessage());
+    }
+
+    @Test
+    void execute_connectionRefused_errorMessage_containsNoServerUrl() {
+        // The server URL (http://localhost:1) must not leak into the returned message
+        var svc = service(SERVER_URL, SemanticExecutionCircuitBreaker.alwaysAllow(SERVER_URL));
+        var result = svc.execute(request());
+
+        assertFalse(result.errorMessage().contains("localhost"),
+                "server URL must not appear in returned error message");
+        assertFalse(result.errorMessage().contains(":1"),
+                "server port must not appear in returned error message");
+    }
+
+    // ── Execute: unexpected HTTP status (UNAVAILABLE) ─────────────────────────
+
+    @Test
+    void execute_unexpectedHttpStatus_returnsUnavailableSafeMessage() throws Exception {
+        String resp = "{\"queryId\":\"q1\",\"state\":\"UNKNOWN_STATE\"}";
+        try (var fake = FakeServer.returning(503, resp)) {
+            var svc = service(fake.baseUrl(), SemanticExecutionCircuitBreaker.alwaysAllow(fake.baseUrl()));
+            var result = svc.execute(request());
+
+            assertEquals(ExecutionStatus.FAILED, result.status());
+            assertEquals(SemanticExecutionFailure.UNAVAILABLE.safeMessage(), result.errorMessage());
+            assertNoForbiddenKeywords(result.errorMessage());
+        }
+    }
+
+    // ── Execute: remote FAILED state (REMOTE_ERROR) ───────────────────────────
+
+    @Test
+    void execute_remoteFailedState_returnsRemoteErrorSafeMessage() throws Exception {
+        // Server accepts 202 → status returns FAILED with a raw server message
+        String submitResp = "{\"queryId\":\"q2\",\"state\":\"QUEUED\"}";
+        String statusResp = "{\"queryId\":\"q2\",\"state\":\"FAILED\","
+                + "\"message\":\"Databricks error: SQL parse error near 'FROM'\"}";
+
+        try (var fake = FakeServer.asyncWithStatus(submitResp, statusResp)) {
+            var svc = service(fake.baseUrl(), SemanticExecutionCircuitBreaker.alwaysAllow(fake.baseUrl()));
+            var result = svc.execute(request());
+
+            assertEquals(ExecutionStatus.FAILED, result.status());
+            assertEquals(SemanticExecutionFailure.REMOTE_ERROR.safeMessage(), result.errorMessage());
+            // Raw server message must NOT propagate to the caller
+            assertFalse(result.errorMessage().contains("Databricks"),
+                    "raw server error message must not appear in result");
+            assertFalse(result.errorMessage().contains("SQL parse error"),
+                    "raw server error detail must not appear in result");
+        }
+    }
+
+    // ── Execute: remote CANCELED state (REMOTE_ERROR) ────────────────────────
+
+    @Test
+    void execute_remoteCanceledState_returnsRemoteErrorSafeMessage() throws Exception {
+        String submitResp = "{\"queryId\":\"q3\",\"state\":\"QUEUED\"}";
+        String statusResp = "{\"queryId\":\"q3\",\"state\":\"CANCELED\"}";
+
+        try (var fake = FakeServer.asyncWithStatus(submitResp, statusResp)) {
+            var svc = service(fake.baseUrl(), SemanticExecutionCircuitBreaker.alwaysAllow(fake.baseUrl()));
+            var result = svc.execute(request());
+
+            assertEquals(ExecutionStatus.FAILED, result.status());
+            assertEquals(SemanticExecutionFailure.REMOTE_ERROR.safeMessage(), result.errorMessage());
+            assertNoForbiddenKeywords(result.errorMessage());
+        }
+    }
+
+    // ── Execute: poll timeout (TIMEOUT) ──────────────────────────────────────
+
+    @Test
+    void execute_pollTimeout_returnsTimeoutSafeMessage() throws Exception {
+        // Submit accepted; status polls return RUNNING; maxWaitMs expires after one poll.
+        String submitResp = "{\"queryId\":\"q4\",\"state\":\"QUEUED\"}";
+        String statusResp = "{\"queryId\":\"q4\",\"state\":\"RUNNING\"}";
+
+        try (var fake = FakeServer.asyncWithStatus(submitResp, statusResp)) {
+            // pollIntervalMs=10 ensures deadline (5ms) is exceeded after one sleep
+            var svc = new SkadiServerQueryExecutionService(
+                    fake.baseUrl(), "jdbc:h2:mem:test", "sa", "",
+                    new ObjectMapper(),
+                    HttpClient.newHttpClient(),
+                    /*pollIntervalMs=*/ 10L,
+                    /*maxWaitMs=*/ 5L,
+                    NoOpSemanticExecutionMetrics.INSTANCE,
+                    SemanticExecutionCircuitBreaker.alwaysAllow(fake.baseUrl()));
+
+            var result = svc.execute(request());
+
+            assertEquals(ExecutionStatus.FAILED, result.status());
+            assertEquals(SemanticExecutionFailure.TIMEOUT.safeMessage(), result.errorMessage());
+            // maxWaitMs value must not appear in returned message
+            assertFalse(result.errorMessage().contains("5"),
+                    "internal timeout duration must not appear in result");
+            assertNoForbiddenKeywords(result.errorMessage());
+        }
+    }
+
+    // ── Execute: success — unaffected ─────────────────────────────────────────
+
+    @Test
+    void execute_cacheHit_successUnchanged() throws Exception {
+        String resp = "{\"queryId\":\"q5\",\"state\":\"SUCCEEDED\"}";
+        try (var fake = FakeServer.returning(200, resp)) {
+            var svc = service(fake.baseUrl(), SemanticExecutionCircuitBreaker.alwaysAllow(fake.baseUrl()));
+            var result = svc.execute(request());
+
+            assertEquals(ExecutionStatus.COMPLETED, result.status());
+            assertNull(result.errorMessage(), "successful result must have no error message");
+        }
+    }
+
+    @Test
+    void execute_asyncSuccess_successUnchanged() throws Exception {
+        String submitResp = "{\"queryId\":\"q6\",\"state\":\"QUEUED\"}";
+        String statusResp = "{\"queryId\":\"q6\",\"state\":\"SUCCEEDED\"}";
+        try (var fake = FakeServer.asyncWithStatus(submitResp, statusResp)) {
+            var svc = service(fake.baseUrl(), SemanticExecutionCircuitBreaker.alwaysAllow(fake.baseUrl()));
+            var result = svc.execute(request());
+
+            assertEquals(ExecutionStatus.COMPLETED, result.status());
+            assertNull(result.errorMessage());
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static QueryExecutionRequest request() {
+        return QueryExecutionRequest.sqlOnly(CTX, SQL, CacheContract.none());
+    }
+
+    private static SkadiServerQueryExecutionService service(String baseUrl,
+                                                             SemanticExecutionCircuitBreaker cb) {
+        return new SkadiServerQueryExecutionService(
+                baseUrl, "jdbc:h2:mem:test", "sa", "s3cr3t",
+                new ObjectMapper(),
+                HttpClient.newHttpClient(),
+                /*pollIntervalMs=*/ 10L,
+                /*maxWaitMs=*/ 5_000L,
+                NoOpSemanticExecutionMetrics.INSTANCE,
+                cb);
+    }
+
+    private static void assertNoForbiddenKeywords(String message) {
+        if (message == null) return;
+        String lower = message.toLowerCase();
+        for (String kw : FORBIDDEN_KEYWORDS) {
+            assertFalse(lower.contains(kw.toLowerCase()),
+                    "error message must not contain '" + kw + "' — got: " + message);
+        }
+    }
+
+    // ── Minimal fake HTTP server ──────────────────────────────────────────────
+
+    static final class FakeServer implements AutoCloseable {
+
+        private final com.sun.net.httpserver.HttpServer server;
+
+        private FakeServer() throws Exception {
+            server = com.sun.net.httpserver.HttpServer.create(
+                    new java.net.InetSocketAddress(0), 0);
+        }
+
+        String baseUrl() {
+            return "http://localhost:" + server.getAddress().getPort();
+        }
+
+        @Override
+        public void close() { server.stop(0); }
+
+        static FakeServer returning(int status, String body) throws Exception {
+            var fake = new FakeServer();
+            fake.server.createContext("/api/v1/queries", exchange -> {
+                exchange.getRequestBody().readAllBytes();
+                byte[] bytes = body.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(status, bytes.length);
+                exchange.getResponseBody().write(bytes);
+                exchange.close();
+            });
+            fake.server.start();
+            return fake;
+        }
+
+        /** POST to /api/v1/queries returns 202 with submitResp; GET status returns statusResp. */
+        static FakeServer asyncWithStatus(String submitResp, String statusResp) throws Exception {
+            var fake = new FakeServer();
+            fake.server.createContext("/api/v1/queries", exchange -> {
+                String method = exchange.getRequestMethod();
+                String payload;
+                int code;
+                if ("POST".equals(method)) {
+                    exchange.getRequestBody().readAllBytes();
+                    payload = submitResp;
+                    code = 202;
+                } else {
+                    payload = statusResp;
+                    code = 200;
+                }
+                byte[] bytes = payload.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(code, bytes.length);
+                exchange.getResponseBody().write(bytes);
+                exchange.close();
+            });
+            fake.server.start();
+            return fake;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SemanticExecutionFailure` enum — 6 values (`DISABLED`, `CIRCUIT_OPEN`, `UNAVAILABLE`, `TIMEOUT`, `REMOTE_ERROR`, `UNEXPECTED`) with `safeMessage()` and `fromHealthStatus()` methods
- All 7 failure paths in `SkadiServerQueryExecutionService` now return the classified stable safe message instead of ad-hoc strings that could contain raw exception text, JDBC URLs, or server-side error details
- Circuit-breaker `recordFailure(reason)` calls also use safe messages — prevents credential/URL leakage via the diagnostics endpoint's `health.lastFailureReason`
- Raw exception details still logged at WARN/ERROR for operator diagnosis
- Success path completely unchanged
- `skadi-sql-gateway`: 0 files changed

## Failure path mapping

| Failure condition | Classification | Safe message |
|---|---|---|
| `isCallAllowed()=false` + DISABLED | `DISABLED` | `semantic execution is disabled` |
| `isCallAllowed()=false` + CIRCUIT_OPEN | `CIRCUIT_OPEN` | `semantic execution circuit is open` |
| Unexpected HTTP status | `UNAVAILABLE` | `semantic execution server is unavailable` |
| `InterruptedException` | `TIMEOUT` | `semantic execution timed out` |
| Any other `Exception` (connection refused, etc.) | `UNEXPECTED` | `semantic execution failed unexpectedly` |
| Remote `FAILED` state | `REMOTE_ERROR` | `remote server reported a query failure` |
| Remote `CANCELED` state | `REMOTE_ERROR` | `remote server reported a query failure` |
| Poll deadline exceeded | `TIMEOUT` | `semantic execution timed out` |

## Test plan

- [x] `./mvnw test -pl skadi-semantic` — 574 tests, 0 failures (18 new in `SemanticExecutionFailureClassificationTest`)
- [x] `./mvnw test -pl skadi-server -am` — 231 tests, 0 failures
- [x] Gateway guardrail: 0 `skadi-sql-gateway` files changed
- [x] `assertNoForbiddenKeywords` guards verify `jdbc:`, `password`, `Exception`, `stack`, etc. absent from all returned messages

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)