### PR TITLE
feat: add demo semantic query DTOs

### DIFF
--- a/skadi-semantic/README.md
+++ b/skadi-semantic/README.md
@@ -97,6 +97,12 @@ for unit tests only. It must not be used in production code.
 ## JSON testing conventions (C2.5)
 
 - Test fixture: `src/test/resources/fixtures/sample-contract.json`
+- Demo spike fixtures (issue #122 / epic #121):
+  - `src/test/resources/fixtures/demo-contract-risk-sensitivity-exposure-grid.json`
+  - `src/test/resources/fixtures/demo-contract-risk-sensitivity-historical-timeseries.json`
+  - These are governed market-risk sensitivity contracts used by the plain-English demo spike.
+    They are test-only fixtures — no production table names, no query execution, no SQL gateway changes.
+    Source view config key wiring is a follow-up TODO documented in each fixture's entity description.
 - `jackson-databind` is a **test-scope** dependency only (version managed by Spring Boot BOM).
 - The `ObjectMapper` in tests is configured with `AUTO_DETECT_IS_GETTERS` disabled.
   Jackson 2.14+ deserialises records via `RecordComponent.getName()` — no `@JsonProperty`

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticExecutionMetadata.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticExecutionMetadata.java
@@ -1,0 +1,58 @@
+package org.iceforge.skadi.semantic.demo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.iceforge.skadi.semantic.service.ExecutionStatus;
+import org.iceforge.skadi.semantic.service.SemanticExecutionFailure;
+
+import java.util.Objects;
+
+/**
+ * Execution metadata for a completed (or failed) demo semantic query.
+ *
+ * <p>Carries enough information for a caller to understand what happened — which
+ * contract was executed, whether the result came from cache, how many rows were
+ * returned, and (if failed) the safe failure classification.
+ *
+ * <p>No SQL, JDBC URLs, or internal stack traces appear here.
+ *
+ * <pre>{@code
+ * // Successful execution
+ * new DemoSemanticExecutionMetadata(
+ *     "risk_sensitivity_exposure_grid", "q-001", null, 42L, 210L,
+ *     ExecutionStatus.COMPLETED, null);
+ *
+ * // Cache hit
+ * new DemoSemanticExecutionMetadata(
+ *     "risk_sensitivity_exposure_grid", "q-002", "FRESH", 42L, null,
+ *     ExecutionStatus.CACHE_HIT, null);
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DemoSemanticExecutionMetadata(
+        String contractId,
+        String queryId,
+        String cacheStatus,
+        long rowCount,
+        Long elapsedMs,
+        ExecutionStatus executionStatus,
+        SemanticExecutionFailure failureClassification) {
+
+    /**
+     * @param contractId             the contract that was executed; must not be null
+     * @param queryId                an opaque query identifier for log correlation; must not be null
+     * @param cacheStatus            cache state string (e.g. "FRESH", "ABSENT"); null when not applicable
+     * @param rowCount               number of rows in the result (0 for failed/unsupported queries)
+     * @param elapsedMs              wall-clock execution time in milliseconds; null when unknown
+     * @param executionStatus        the terminal execution status; must not be null
+     * @param failureClassification  safe failure category; must be null unless status is FAILED
+     */
+    public DemoSemanticExecutionMetadata {
+        Objects.requireNonNull(contractId,       "contractId must not be null");
+        Objects.requireNonNull(queryId,          "queryId must not be null");
+        Objects.requireNonNull(executionStatus,  "executionStatus must not be null");
+        if (executionStatus != ExecutionStatus.FAILED && failureClassification != null) {
+            throw new IllegalArgumentException(
+                    "failureClassification must be null when status is not FAILED, was: " + executionStatus);
+        }
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticFilter.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticFilter.java
@@ -1,0 +1,61 @@
+package org.iceforge.skadi.semantic.demo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A single filter criterion in a {@link DemoSemanticQueryInterpretation}.
+ *
+ * <p>Supports three filter forms:
+ * <ul>
+ *   <li><b>Equality</b> — {@link #name()} + {@link #value()}, operator null or "EQ"</li>
+ *   <li><b>IN-style</b> — {@link #name()} + {@link #values()} list, operator "IN"</li>
+ *   <li><b>Date range</b> — {@link #name()} + {@link #start()} / {@link #end()},
+ *       operator "BETWEEN"; date math strings (e.g. "last_30_days") are also
+ *       accepted in {@link #value()} and resolved by the future renderer</li>
+ * </ul>
+ *
+ * <p>Unused optional fields are null; Jackson skips them via {@link JsonInclude}.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DemoSemanticFilter(
+        String name,
+        String value,
+        String operator,
+        List<String> values,
+        String start,
+        String end) {
+
+    /**
+     * @param name     filter dimension name; must not be null or blank
+     * @param value    simple equality value; null for IN or range filters
+     * @param operator optional operator string (e.g. "EQ", "IN", "BETWEEN"); null defaults to EQ
+     * @param values   value list for IN-style filters; null otherwise; copied defensively
+     * @param start    range start (date string or token); null if not a range filter
+     * @param end      range end (date string or token); null if not a range filter
+     */
+    public DemoSemanticFilter {
+        Objects.requireNonNull(name, "name must not be null");
+        if (name.isBlank()) throw new IllegalArgumentException("name must not be blank");
+        values = values == null ? null : List.copyOf(values);
+    }
+
+    /** Convenience constructor for a simple equality filter. */
+    public static DemoSemanticFilter eq(String name, String value) {
+        Objects.requireNonNull(value, "value must not be null for equality filter");
+        return new DemoSemanticFilter(name, value, null, null, null, null);
+    }
+
+    /** Convenience constructor for an IN-style filter. */
+    public static DemoSemanticFilter in(String name, List<String> values) {
+        Objects.requireNonNull(values, "values must not be null for IN filter");
+        return new DemoSemanticFilter(name, null, "IN", values, null, null);
+    }
+
+    /** Convenience constructor for a date-range filter. */
+    public static DemoSemanticFilter between(String name, String start, String end) {
+        return new DemoSemanticFilter(name, null, "BETWEEN", null, start, end);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticInterpretationConfidence.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticInterpretationConfidence.java
@@ -1,0 +1,27 @@
+package org.iceforge.skadi.semantic.demo;
+
+/**
+ * Confidence level assigned to a {@link DemoSemanticQueryInterpretation}.
+ *
+ * <p>Set by the (future) plain-English interpreter to indicate how confidently
+ * the free-text request could be mapped to a governed semantic contract.
+ * Consumers should surface LOW/AMBIGUOUS confidence to users and reject
+ * UNSUPPORTED requests before attempting SQL rendering or execution.
+ */
+public enum DemoSemanticInterpretationConfidence {
+
+    /** The request was unambiguously matched to a single contract and measure. */
+    HIGH,
+
+    /** The request was matched but with some uncertainty (e.g. a plausible guess at measure). */
+    MEDIUM,
+
+    /** The request was matched but multiple interpretations were plausible. */
+    LOW,
+
+    /** The request cannot be fulfilled by any registered demo contract. */
+    UNSUPPORTED,
+
+    /** The request matched multiple contracts or measures and cannot be resolved without clarification. */
+    AMBIGUOUS
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticOutputShape.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticOutputShape.java
@@ -1,0 +1,17 @@
+package org.iceforge.skadi.semantic.demo;
+
+/**
+ * The requested output shape for a demo semantic query.
+ *
+ * <p>GRID requests a tabular cross-section (group-by across one or more risk
+ * dimensions on a single COB date). TIMESERIES requests a date-ordered series
+ * grouped by one or more slice keys.
+ */
+public enum DemoSemanticOutputShape {
+
+    /** Tabular exposure grid — one row per grouping cell on a single COB date. */
+    GRID,
+
+    /** Date-ordered time series — one row per (cob_date, grouping key) combination. */
+    TIMESERIES
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticQueryExecutionResponse.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticQueryExecutionResponse.java
@@ -1,0 +1,61 @@
+package org.iceforge.skadi.semantic.demo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.iceforge.skadi.semantic.request.SemanticValidationOutcome;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The full response for a demo semantic query execution.
+ *
+ * <p>Carries the original request text, the interpretation that was derived from
+ * it, the validation outcome (allowed or denied), execution metadata, the column
+ * descriptors for the result, and the result rows.
+ *
+ * <p>When validation is denied or the interpretation is not executable,
+ * {@link #columns()} and {@link #rows()} will typically be empty.
+ *
+ * <p>Result rows are plain {@code Map<String, Object>} keyed by column name,
+ * matching the column names in {@link #columns()}.
+ *
+ * <pre>{@code
+ * new DemoSemanticQueryExecutionResponse(
+ *     "Show delta exposure by legal entity for CIB USD as of 2026-05-15",
+ *     interpretation,
+ *     SemanticValidationOutcome.allowed("risk_sensitivity_exposure_grid", "OK"),
+ *     metadata,
+ *     List.of(new DemoSemanticResultColumn("legal_entity", "Legal Entity", "STRING", "DIMENSION"),
+ *             new DemoSemanticResultColumn("delta_exposure", "Delta Exposure", "DECIMAL", "MEASURE")),
+ *     List.of(Map.of("legal_entity", "CIB-US", "delta_exposure", 12345.67)));
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DemoSemanticQueryExecutionResponse(
+        String requestText,
+        DemoSemanticQueryInterpretation interpretation,
+        SemanticValidationOutcome validation,
+        DemoSemanticExecutionMetadata metadata,
+        List<DemoSemanticResultColumn> columns,
+        List<Map<String, Object>> rows) {
+
+    /**
+     * @param requestText    the original plain-English text; must not be null
+     * @param interpretation the semantic interpretation; must not be null
+     * @param validation     the validation outcome; must not be null
+     * @param metadata       execution metadata; must not be null
+     * @param columns        result column descriptors; must not be null; outer list copied defensively
+     * @param rows           result rows keyed by column name; must not be null; outer list copied defensively
+     */
+    public DemoSemanticQueryExecutionResponse {
+        Objects.requireNonNull(requestText,    "requestText must not be null");
+        Objects.requireNonNull(interpretation, "interpretation must not be null");
+        Objects.requireNonNull(validation,     "validation must not be null");
+        Objects.requireNonNull(metadata,       "metadata must not be null");
+        Objects.requireNonNull(columns,        "columns must not be null");
+        Objects.requireNonNull(rows,           "rows must not be null");
+        columns = List.copyOf(columns);
+        rows    = List.copyOf(rows);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticQueryInterpretation.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticQueryInterpretation.java
@@ -1,0 +1,77 @@
+package org.iceforge.skadi.semantic.demo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The result of interpreting a plain-English demo query request.
+ *
+ * <p>An interpretation maps free-form text to a specific governed contract,
+ * measure, groupings, filters, and output shape. It does not include SQL or
+ * internal rendering details.
+ *
+ * <p>The {@link #confidence()} field indicates how reliably the text could be
+ * mapped. Callers should check confidence before proceeding to rendering or
+ * execution — UNSUPPORTED and AMBIGUOUS interpretations must not be executed.
+ *
+ * <p>{@link #warnings()} carries non-fatal advisory notes (e.g. a dimension
+ * that was inferred rather than stated explicitly).
+ *
+ * <pre>{@code
+ * // Exposure-grid interpretation
+ * new DemoSemanticQueryInterpretation(
+ *     "Show me delta exposure by legal entity and risk class for CIB USD as of 2026-05-15",
+ *     "risk_sensitivity_exposure_grid",
+ *     "delta_exposure",
+ *     List.of("legal_entity", "risk_class"),
+ *     List.of(DemoSemanticFilter.eq("org", "CIB"),
+ *             DemoSemanticFilter.eq("currency", "USD"),
+ *             DemoSemanticFilter.eq("cob_date", "2026-05-15")),
+ *     DemoSemanticOutputShape.GRID,
+ *     DemoSemanticInterpretationConfidence.HIGH,
+ *     List.of());
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DemoSemanticQueryInterpretation(
+        String originalText,
+        String contractId,
+        String measure,
+        List<String> groupBy,
+        List<DemoSemanticFilter> filters,
+        DemoSemanticOutputShape outputShape,
+        DemoSemanticInterpretationConfidence confidence,
+        List<String> warnings) {
+
+    /**
+     * @param originalText the original plain-English text; must not be null
+     * @param contractId   the matched contract name; null when confidence is UNSUPPORTED
+     * @param measure      the matched measure name; null when confidence is UNSUPPORTED
+     * @param groupBy      group-by dimension names; must not be null; copied defensively
+     * @param filters      filter criteria; must not be null; copied defensively
+     * @param outputShape  intended output shape; must not be null
+     * @param confidence   interpretation confidence level; must not be null
+     * @param warnings     advisory notes; must not be null; copied defensively
+     */
+    public DemoSemanticQueryInterpretation {
+        Objects.requireNonNull(originalText, "originalText must not be null");
+        Objects.requireNonNull(groupBy,      "groupBy must not be null");
+        Objects.requireNonNull(filters,      "filters must not be null");
+        Objects.requireNonNull(outputShape,  "outputShape must not be null");
+        Objects.requireNonNull(confidence,   "confidence must not be null");
+        Objects.requireNonNull(warnings,     "warnings must not be null");
+        groupBy  = List.copyOf(groupBy);
+        filters  = List.copyOf(filters);
+        warnings = List.copyOf(warnings);
+    }
+
+    /** Returns true if this interpretation can proceed to SQL rendering and execution. */
+    public boolean isExecutable() {
+        return confidence != DemoSemanticInterpretationConfidence.UNSUPPORTED
+                && confidence != DemoSemanticInterpretationConfidence.AMBIGUOUS
+                && contractId != null
+                && measure != null;
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticQueryRequest.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticQueryRequest.java
@@ -1,0 +1,44 @@
+package org.iceforge.skadi.semantic.demo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+/**
+ * A plain-English query request for the market-risk sensitivity demo.
+ *
+ * <p>This is the raw inbound DTO — the caller provides free-form {@link #text()}
+ * and an optional {@link #limit()}. The text is passed to the (future)
+ * plain-English interpreter which produces a {@link DemoSemanticQueryInterpretation}.
+ *
+ * <p>No SQL, no contract IDs, and no measure names appear here; those are
+ * resolved by the interpreter, not the caller.
+ *
+ * <pre>{@code
+ * new DemoSemanticQueryRequest(
+ *     "Show me delta exposure by legal entity and risk class for CIB in USD as of 2026-05-15",
+ *     null);
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DemoSemanticQueryRequest(
+        String text,
+        Integer limit) {
+
+    /**
+     * @param text  plain-English query text; must not be null or blank
+     * @param limit optional row limit; null means no limit
+     */
+    public DemoSemanticQueryRequest {
+        Objects.requireNonNull(text, "text must not be null");
+        if (text.isBlank()) throw new IllegalArgumentException("text must not be blank");
+        if (limit != null && limit <= 0) {
+            throw new IllegalArgumentException("limit must be positive when set, was: " + limit);
+        }
+    }
+
+    /** Convenience constructor with no limit. */
+    public DemoSemanticQueryRequest(String text) {
+        this(text, null);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticResultColumn.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticResultColumn.java
@@ -1,0 +1,44 @@
+package org.iceforge.skadi.semantic.demo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+/**
+ * Descriptor for a single column in a {@link DemoSemanticQueryExecutionResponse}.
+ *
+ * <p>Carries the column identifier, a UI-friendly display name, the logical data
+ * type string, and an optional semantic role hint for chart-axis binding.
+ *
+ * <pre>{@code
+ * new DemoSemanticResultColumn("delta_exposure", "Delta Exposure", "DECIMAL", "MEASURE");
+ * new DemoSemanticResultColumn("legal_entity",   "Legal Entity",   "STRING",  "DIMENSION");
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DemoSemanticResultColumn(
+        String name,
+        String displayName,
+        String dataType,
+        String semanticRole) {
+
+    /**
+     * @param name         column identifier matching result row keys; must not be null or blank
+     * @param displayName  human-readable label for UI; must not be null
+     * @param dataType     logical data type string (e.g. "DECIMAL", "STRING", "DATE");
+     *                     must not be null
+     * @param semanticRole optional semantic role hint (e.g. "MEASURE", "DIMENSION",
+     *                     "TIME_AXIS"); null when not declared
+     */
+    public DemoSemanticResultColumn {
+        Objects.requireNonNull(name,        "name must not be null");
+        Objects.requireNonNull(displayName, "displayName must not be null");
+        Objects.requireNonNull(dataType,    "dataType must not be null");
+        if (name.isBlank()) throw new IllegalArgumentException("name must not be blank");
+    }
+
+    /** Convenience constructor with no semantic role. */
+    public DemoSemanticResultColumn(String name, String displayName, String dataType) {
+        this(name, displayName, dataType, null);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/package-info.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * Demo semantic query DTOs for the market-risk sensitivity plain-English demo.
+ *
+ * <p>This package contains the request/response model types that carry an
+ * interpreted plain-English query through validation, future SQL-template
+ * rendering, execution, and result return. It does not implement the interpreter,
+ * SQL renderer, or any execution logic.
+ *
+ * <p>Entry points:
+ * <ul>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticQueryRequest} — plain-text input</li>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticQueryInterpretation} — interpreter output</li>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticQueryExecutionResponse} — full execution response</li>
+ * </ul>
+ */
+package org.iceforge.skadi.semantic.demo;

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/DemoMarketRiskContractTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/DemoMarketRiskContractTest.java
@@ -1,0 +1,399 @@
+package org.iceforge.skadi.semantic;
+
+import org.iceforge.skadi.semantic.contract.SemanticCacheStrategy;
+import org.iceforge.skadi.semantic.contract.SemanticContract;
+import org.iceforge.skadi.semantic.contract.SemanticDimension;
+import org.iceforge.skadi.semantic.contract.SemanticFieldType;
+import org.iceforge.skadi.semantic.contract.SemanticMeasure;
+import org.iceforge.skadi.semantic.loader.ContractLoader;
+import org.iceforge.skadi.semantic.loader.JsonContractLoader;
+import org.iceforge.skadi.semantic.registry.ContractRegistryPopulator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Demo spike fixtures for issue #122 / epic #121.
+ *
+ * <p>Verifies that the two market-risk sensitivity demo contracts
+ * ({@code risk_sensitivity_exposure_grid} and
+ * {@code risk_sensitivity_historical_timeseries}) load correctly, that their
+ * metadata is preserved, and that existing minimal contract fixtures remain
+ * backward-compatible.
+ *
+ * <p>No Spring context, no Databricks, no S3, no network I/O, no SQL execution,
+ * no skadi-sql-gateway changes.
+ */
+class DemoMarketRiskContractTest {
+
+    private static final String EXPOSURE_GRID     = "/fixtures/demo-contract-risk-sensitivity-exposure-grid.json";
+    private static final String HISTORY_TIMESERIES = "/fixtures/demo-contract-risk-sensitivity-historical-timeseries.json";
+    private static final String SAMPLE_CONTRACT    = "/fixtures/sample-contract.json";
+
+    private ContractLoader loader;
+
+    @BeforeEach
+    void setUp() {
+        loader = JsonContractLoader.create();
+    }
+
+    // ── Test 1: Existing minimal contract fixture still loads (backward compat) ─
+
+    @Test
+    void existingSampleContract_stillLoads_backwardCompatible() throws Exception {
+        try (InputStream in = stream(SAMPLE_CONTRACT)) {
+            SemanticContract c = loader.load(in);
+            assertEquals("mxl_risk", c.name());
+            assertEquals("1.0.0",    c.version().value());
+            assertEquals(2,          c.measures().size());
+            assertEquals(3,          c.dimensions().size());
+        }
+    }
+
+    // ── Test 2: Exposure-grid demo contract loads ──────────────────────────────
+
+    @Test
+    void exposureGridDemoContract_loads_successfully() throws Exception {
+        try (InputStream in = stream(EXPOSURE_GRID)) {
+            SemanticContract c = loader.load(in);
+            assertNotNull(c);
+            assertEquals("risk_sensitivity_exposure_grid", c.name());
+        }
+    }
+
+    // ── Test 3: Historical timeseries demo contract loads ─────────────────────
+
+    @Test
+    void historicalTimeseriesDemoContract_loads_successfully() throws Exception {
+        try (InputStream in = stream(HISTORY_TIMESERIES)) {
+            SemanticContract c = loader.load(in);
+            assertNotNull(c);
+            assertEquals("risk_sensitivity_historical_timeseries", c.name());
+        }
+    }
+
+    // ── Test 4: ContractRegistry returns both demo contracts ──────────────────
+
+    @Test
+    void registry_populatedWithBothDemoContracts_containsBoth() throws Exception {
+        SemanticContract grid;
+        SemanticContract ts;
+        try (InputStream in = stream(EXPOSURE_GRID)) {
+            grid = loader.load(in);
+        }
+        try (InputStream in = stream(HISTORY_TIMESERIES)) {
+            ts = loader.load(in);
+        }
+
+        var populator = ContractRegistryPopulator.create();
+        var registry  = populator.populate(List.of(grid, ts));
+
+        assertTrue(registry.contains("risk_sensitivity_exposure_grid"));
+        assertTrue(registry.contains("risk_sensitivity_historical_timeseries"));
+        assertEquals(2, registry.list().size());
+
+        var found = registry.findByName("risk_sensitivity_exposure_grid");
+        assertTrue(found.isPresent());
+        assertEquals("risk_sensitivity_exposure_grid", found.get().name());
+    }
+
+    // ── Test 5: Contract-level metadata is preserved ──────────────────────────
+
+    @Test
+    void exposureGrid_contractMetadata_isPreserved() throws Exception {
+        try (InputStream in = stream(EXPOSURE_GRID)) {
+            SemanticContract c = loader.load(in);
+            assertEquals("risk_sensitivity_exposure_grid", c.name());
+            assertEquals("1.0.0", c.version().value());
+            assertFalse(c.description().isBlank(), "description must not be blank");
+            assertTrue(c.description().contains("exposure grid"),
+                    "description should mention 'exposure grid'");
+            assertEquals("risk_sensitivity_exposure_grid", c.entity().name());
+            assertFalse(c.entity().description().isBlank(), "entity description must not be blank");
+        }
+    }
+
+    @Test
+    void historicalTimeseries_contractMetadata_isPreserved() throws Exception {
+        try (InputStream in = stream(HISTORY_TIMESERIES)) {
+            SemanticContract c = loader.load(in);
+            assertEquals("risk_sensitivity_historical_timeseries", c.name());
+            assertEquals("1.0.0", c.version().value());
+            assertFalse(c.description().isBlank(), "description must not be blank");
+            assertTrue(c.description().contains("time-series"),
+                    "description should mention 'time-series'");
+            assertEquals("risk_sensitivity_historical_timeseries", c.entity().name());
+            assertFalse(c.entity().description().isBlank(), "entity description must not be blank");
+        }
+    }
+
+    // ── Test 6: Measure-level metadata is preserved ───────────────────────────
+
+    @Test
+    void exposureGrid_measureMetadata_isPreserved() throws Exception {
+        try (InputStream in = stream(EXPOSURE_GRID)) {
+            SemanticContract c = loader.load(in);
+            assertEquals(4, c.measures().size());
+
+            var names = c.measures().stream().map(SemanticMeasure::name).toList();
+            assertEquals(List.of("delta_exposure", "dv01", "vega", "gamma"), names);
+
+            assertMeasure(c, "delta_exposure", "Delta Exposure",    "SUM(delta_exposure)", SemanticFieldType.DECIMAL);
+            assertMeasure(c, "dv01",           "DV01",              "SUM(dv01)",           SemanticFieldType.DECIMAL);
+            assertMeasure(c, "vega",           "Vega",              "SUM(vega)",           SemanticFieldType.DECIMAL);
+            assertMeasure(c, "gamma",          "Gamma",             "SUM(gamma)",          SemanticFieldType.DECIMAL);
+        }
+    }
+
+    @Test
+    void historicalTimeseries_measureMetadata_isPreserved() throws Exception {
+        try (InputStream in = stream(HISTORY_TIMESERIES)) {
+            SemanticContract c = loader.load(in);
+            assertEquals(4, c.measures().size());
+
+            var names = c.measures().stream().map(SemanticMeasure::name).toList();
+            assertEquals(List.of("delta_exposure", "dv01", "vega", "gamma"), names);
+
+            assertMeasure(c, "delta_exposure", "Delta Exposure",    "SUM(delta_exposure)", SemanticFieldType.DECIMAL);
+            assertMeasure(c, "dv01",           "DV01",              "SUM(dv01)",           SemanticFieldType.DECIMAL);
+            assertMeasure(c, "vega",           "Vega",              "SUM(vega)",           SemanticFieldType.DECIMAL);
+            assertMeasure(c, "gamma",          "Gamma",             "SUM(gamma)",          SemanticFieldType.DECIMAL);
+        }
+    }
+
+    @Test
+    void measures_descriptionIsPreserved_notBlank() throws Exception {
+        try (InputStream in = stream(EXPOSURE_GRID)) {
+            SemanticContract c = loader.load(in);
+            for (SemanticMeasure m : c.measures()) {
+                assertFalse(m.description().isBlank(),
+                        "measure '" + m.name() + "' description must not be blank");
+            }
+        }
+    }
+
+    // ── Test 7: Dimension-level metadata is preserved ─────────────────────────
+
+    @Test
+    void exposureGrid_dimensionMetadata_isPreserved() throws Exception {
+        try (InputStream in = stream(EXPOSURE_GRID)) {
+            SemanticContract c = loader.load(in);
+            assertEquals(8, c.dimensions().size());
+
+            var names = c.dimensions().stream().map(SemanticDimension::name).toList();
+            assertEquals(List.of(
+                    "cob_date", "legal_entity", "business_unit", "desk",
+                    "risk_class", "risk_factor", "currency", "product"), names);
+
+            assertDimensionColumn(c, "cob_date",       "cob_date",       SemanticFieldType.DATE,   "Close of Business Date");
+            assertDimensionColumn(c, "legal_entity",   "legal_entity",   SemanticFieldType.STRING, "Legal Entity");
+            assertDimensionColumn(c, "business_unit",  "business_unit",  SemanticFieldType.STRING, "Business Unit");
+            assertDimensionColumn(c, "desk",           "desk",           SemanticFieldType.STRING, "Trading Desk");
+            assertDimensionColumn(c, "risk_class",     "risk_class",     SemanticFieldType.STRING, "Risk Class");
+            assertDimensionColumn(c, "risk_factor",    "risk_factor",    SemanticFieldType.STRING, "Risk Factor");
+            assertDimensionColumn(c, "currency",       "currency",       SemanticFieldType.STRING, "Currency");
+            assertDimensionColumn(c, "product",        "product",        SemanticFieldType.STRING, "Product");
+        }
+    }
+
+    @Test
+    void historicalTimeseries_dimensionMetadata_isPreserved() throws Exception {
+        try (InputStream in = stream(HISTORY_TIMESERIES)) {
+            SemanticContract c = loader.load(in);
+            assertEquals(8, c.dimensions().size());
+
+            var names = c.dimensions().stream().map(SemanticDimension::name).toList();
+            assertEquals(List.of(
+                    "cob_date", "legal_entity", "business_unit", "desk",
+                    "risk_class", "risk_factor", "currency", "product"), names);
+
+            assertDimensionColumn(c, "cob_date", "cob_date", SemanticFieldType.DATE, "Close of Business Date");
+            assertDimensionColumn(c, "desk",     "desk",     SemanticFieldType.STRING, "Trading Desk");
+            assertDimensionColumn(c, "risk_class","risk_class", SemanticFieldType.STRING, "Risk Class");
+        }
+    }
+
+    // ── Test 8: Groupable/filterable flags are preserved ──────────────────────
+
+    @Test
+    void exposureGrid_filterableGroupableFlags_areCorrect() throws Exception {
+        try (InputStream in = stream(EXPOSURE_GRID)) {
+            SemanticContract c = loader.load(in);
+
+            // cob_date — filterable and groupable (supports date-range filter AND grid grouping)
+            assertFlags(c, "cob_date",      true,  true);
+            // core groupable risk dimensions
+            assertFlags(c, "legal_entity",  true,  true);
+            assertFlags(c, "business_unit", true,  true);
+            assertFlags(c, "desk",          true,  true);
+            assertFlags(c, "risk_class",    true,  true);
+            assertFlags(c, "risk_factor",   true,  true);
+            assertFlags(c, "currency",      true,  true);
+            // product — filterable but not groupable (too fine-grained for grid grouping)
+            assertFlags(c, "product",       true,  false);
+        }
+    }
+
+    @Test
+    void historicalTimeseries_filterableGroupableFlags_areCorrect() throws Exception {
+        try (InputStream in = stream(HISTORY_TIMESERIES)) {
+            SemanticContract c = loader.load(in);
+
+            // cob_date — time axis: filterable and groupable
+            assertFlags(c, "cob_date",      true,  true);
+            // groupable: legal_entity, desk, risk_class (common time-series slice keys)
+            assertFlags(c, "legal_entity",  true,  true);
+            assertFlags(c, "desk",          true,  true);
+            assertFlags(c, "risk_class",    true,  true);
+            // context filters only — not groupable in a time-series shape
+            assertFlags(c, "business_unit", true,  false);
+            assertFlags(c, "risk_factor",   true,  false);
+            assertFlags(c, "currency",      true,  false);
+            // product — not applicable for time-series shape
+            assertFlags(c, "product",       false, false);
+        }
+    }
+
+    // ── Test 9: Output shape metadata preserved where supported ───────────────
+    // SemanticContract does not carry a SemanticOutputShape field — that lives in
+    // SemanticQueryContract (query package, C3). Shape intent is documented in the
+    // entity description field as a grain note.
+
+    @Test
+    void exposureGrid_entityDescription_containsGrainAndOutputShapeNote() throws Exception {
+        try (InputStream in = stream(EXPOSURE_GRID)) {
+            String entityDesc = loader.load(in).entity().description();
+            assertTrue(entityDesc.contains("Grain:"),
+                    "entity description should document grain");
+            assertTrue(entityDesc.contains("Output shape:"),
+                    "entity description should document output shape intent");
+        }
+    }
+
+    @Test
+    void historicalTimeseries_entityDescription_containsGrainAndOutputShapeNote() throws Exception {
+        try (InputStream in = stream(HISTORY_TIMESERIES)) {
+            String entityDesc = loader.load(in).entity().description();
+            assertTrue(entityDesc.contains("Grain:"),
+                    "entity description should document grain");
+            assertTrue(entityDesc.contains("Output shape:"),
+                    "entity description should document output shape intent");
+        }
+    }
+
+    // ── Test 10: Missing optional metadata remains safe / backward-compatible ──
+
+    @Test
+    void existingSampleContract_withNoPolicyRuleRefs_loadsWithoutError() throws Exception {
+        try (InputStream in = stream(SAMPLE_CONTRACT)) {
+            SemanticContract c = loader.load(in);
+            // access policy rule refs present (non-empty in sample-contract.json)
+            assertNotNull(c.accessPolicy().ruleRefs());
+            // cache policy rule refs present (empty list is fine)
+            assertNotNull(c.cachePolicy().ruleRefs());
+        }
+    }
+
+    @Test
+    void demoContracts_emptyPrincipalsList_loadsSafely() throws Exception {
+        for (String fixture : List.of(EXPOSURE_GRID, HISTORY_TIMESERIES)) {
+            try (InputStream in = stream(fixture)) {
+                SemanticContract c = loader.load(in);
+                // allowedPrincipals is empty in demo fixtures — must not cause NPE or error
+                assertNotNull(c.accessPolicy().allowedPrincipals());
+                assertTrue(c.accessPolicy().allowedPrincipals().isEmpty(),
+                        "demo fixture '" + c.name() + "' should have no explicit principals");
+                assertThrows(UnsupportedOperationException.class,
+                        () -> c.accessPolicy().allowedPrincipals().add(null),
+                        "principals list must be unmodifiable");
+            }
+        }
+    }
+
+    @Test
+    void demoContracts_cachePolicyIsTtl3600() throws Exception {
+        for (String fixture : List.of(EXPOSURE_GRID, HISTORY_TIMESERIES)) {
+            try (InputStream in = stream(fixture)) {
+                var cache = loader.load(in).cachePolicy();
+                assertEquals(SemanticCacheStrategy.TTL, cache.strategy());
+                assertEquals(3600L, cache.ttlSeconds());
+            }
+        }
+    }
+
+    @Test
+    void demoContracts_accessPolicyRoles_arePreserved() throws Exception {
+        for (String fixture : List.of(EXPOSURE_GRID, HISTORY_TIMESERIES)) {
+            try (InputStream in = stream(fixture)) {
+                var policy = loader.load(in).accessPolicy();
+                assertEquals(2, policy.allowedRoles().size());
+                var roleNames = policy.allowedRoles().stream()
+                        .map(r -> r.name()).toList();
+                assertTrue(roleNames.contains("risk_analyst"));
+                assertTrue(roleNames.contains("risk_viewer"));
+            }
+        }
+    }
+
+    @Test
+    void demoContracts_measuresAndDimensions_areUnmodifiable() throws Exception {
+        for (String fixture : List.of(EXPOSURE_GRID, HISTORY_TIMESERIES)) {
+            try (InputStream in = stream(fixture)) {
+                SemanticContract c = loader.load(in);
+                assertThrows(UnsupportedOperationException.class,
+                        () -> c.measures().add(null),
+                        "measures must be unmodifiable for " + c.name());
+                assertThrows(UnsupportedOperationException.class,
+                        () -> c.dimensions().add(null),
+                        "dimensions must be unmodifiable for " + c.name());
+            }
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private InputStream stream(String classpathResource) {
+        InputStream in = getClass().getResourceAsStream(classpathResource);
+        assertNotNull(in, "classpath resource not found: " + classpathResource);
+        return in;
+    }
+
+    private static void assertMeasure(SemanticContract c, String name, String label,
+                                      String expression, SemanticFieldType type) {
+        SemanticMeasure m = c.measures().stream()
+                .filter(x -> x.name().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("measure not found: " + name));
+        assertEquals(label,      m.label(),      "label for measure '" + name + "'");
+        assertEquals(expression, m.expression(), "expression for measure '" + name + "'");
+        assertEquals(type,       m.type(),       "type for measure '" + name + "'");
+        assertFalse(m.description().isBlank(),   "description for measure '" + name + "' must not be blank");
+    }
+
+    private static void assertDimensionColumn(SemanticContract c, String name, String column,
+                                              SemanticFieldType type, String label) {
+        SemanticDimension d = c.dimensions().stream()
+                .filter(x -> x.name().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("dimension not found: " + name));
+        assertEquals(column, d.column(), "column for dimension '" + name + "'");
+        assertEquals(type,   d.type(),   "type for dimension '" + name + "'");
+        assertEquals(label,  d.label(),  "label for dimension '" + name + "'");
+    }
+
+    private static void assertFlags(SemanticContract c, String dimName,
+                                    boolean expectedFilterable, boolean expectedGroupable) {
+        SemanticDimension d = c.dimensions().stream()
+                .filter(x -> x.name().equals(dimName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("dimension not found: " + dimName));
+        assertEquals(expectedFilterable, d.filterable(),
+                "filterable flag for '" + dimName + "'");
+        assertEquals(expectedGroupable,  d.groupable(),
+                "groupable flag for '" + dimName + "'");
+    }
+}

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/demo/DemoSemanticQueryDtoTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/demo/DemoSemanticQueryDtoTest.java
@@ -1,0 +1,543 @@
+package org.iceforge.skadi.semantic.demo;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.iceforge.skadi.semantic.request.SemanticValidationOutcome;
+import org.iceforge.skadi.semantic.request.SemanticValidationReasonCode;
+import org.iceforge.skadi.semantic.service.ExecutionStatus;
+import org.iceforge.skadi.semantic.service.SemanticExecutionFailure;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the demo semantic query DTOs.
+ *
+ * <p>Covers issue #123 definition-of-done criteria:
+ * DTOs represent exposure-grid and historical-time-series requests,
+ * Jackson round-trips, validation outcomes, denied/unsupported interpretations,
+ * execution metadata, result rows, and absence of raw SQL fields.
+ *
+ * <p>No Spring context, no Databricks, no S3, no network calls,
+ * no skadi-sql-gateway changes.
+ */
+class DemoSemanticQueryDtoTest {
+
+    private static final String GRID_CONTRACT = "risk_sensitivity_exposure_grid";
+    private static final String TS_CONTRACT   = "risk_sensitivity_historical_timeseries";
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper()
+                .disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+    }
+
+    // ── 1. DTOs can represent exposure-grid requests ───────────────────────────
+
+    @Test
+    void exposureGrid_queryRequest_holdsText() {
+        var req = new DemoSemanticQueryRequest(
+                "Show me delta exposure by legal entity and risk class for CIB in USD as of 2026-05-15");
+        assertEquals(
+                "Show me delta exposure by legal entity and risk class for CIB in USD as of 2026-05-15",
+                req.text());
+        assertNull(req.limit());
+    }
+
+    @Test
+    void exposureGrid_interpretation_holdsAllFields() {
+        var interp = exposureGridInterpretation();
+
+        assertEquals(GRID_CONTRACT,                              interp.contractId());
+        assertEquals("delta_exposure",                          interp.measure());
+        assertEquals(List.of("legal_entity", "risk_class"),     interp.groupBy());
+        assertEquals(DemoSemanticOutputShape.GRID,              interp.outputShape());
+        assertEquals(DemoSemanticInterpretationConfidence.HIGH, interp.confidence());
+        assertTrue(interp.warnings().isEmpty());
+    }
+
+    @Test
+    void exposureGrid_filters_arePreserved() {
+        var interp = exposureGridInterpretation();
+
+        assertEquals(3, interp.filters().size());
+        assertTrue(interp.filters().stream().anyMatch(f -> f.name().equals("org")      && "CIB".equals(f.value())));
+        assertTrue(interp.filters().stream().anyMatch(f -> f.name().equals("currency") && "USD".equals(f.value())));
+        assertTrue(interp.filters().stream().anyMatch(f -> f.name().equals("cob_date") && "2026-05-15".equals(f.value())));
+    }
+
+    @Test
+    void exposureGrid_interpretation_isExecutable() {
+        assertTrue(exposureGridInterpretation().isExecutable());
+    }
+
+    // ── 2. DTOs can represent historical-time-series requests ─────────────────
+
+    @Test
+    void timeseries_queryRequest_holdsText() {
+        var req = new DemoSemanticQueryRequest(
+                "Show dv01 trend by desk for CIB rates over the last 30 days", 100);
+        assertEquals("Show dv01 trend by desk for CIB rates over the last 30 days", req.text());
+        assertEquals(100, req.limit());
+    }
+
+    @Test
+    void timeseries_interpretation_holdsAllFields() {
+        var interp = timeseriesInterpretation();
+
+        assertEquals(TS_CONTRACT,                               interp.contractId());
+        assertEquals("dv01",                                    interp.measure());
+        assertEquals(List.of("desk"),                           interp.groupBy());
+        assertEquals(DemoSemanticOutputShape.TIMESERIES,        interp.outputShape());
+        assertEquals(DemoSemanticInterpretationConfidence.HIGH, interp.confidence());
+    }
+
+    @Test
+    void timeseries_filters_includeDateRange() {
+        var interp = timeseriesInterpretation();
+
+        assertTrue(interp.filters().stream().anyMatch(f -> f.name().equals("org")        && "CIB".equals(f.value())));
+        assertTrue(interp.filters().stream().anyMatch(f -> f.name().equals("risk_class") && "rates".equals(f.value())));
+        assertTrue(interp.filters().stream().anyMatch(f -> f.name().equals("date_range") && "last_30_days".equals(f.value())));
+    }
+
+    @Test
+    void timeseries_interpretation_isExecutable() {
+        assertTrue(timeseriesInterpretation().isExecutable());
+    }
+
+    // ── 3. Jackson round-trip ─────────────────────────────────────────────────
+
+    @Test
+    void jacksonRoundTrip_queryRequest() throws Exception {
+        var req = new DemoSemanticQueryRequest("Show delta exposure for CIB", 50);
+        var rt  = mapper.readValue(mapper.writeValueAsString(req), DemoSemanticQueryRequest.class);
+        assertEquals(req.text(),  rt.text());
+        assertEquals(req.limit(), rt.limit());
+    }
+
+    @Test
+    void jacksonRoundTrip_queryRequest_noLimit() throws Exception {
+        var req = new DemoSemanticQueryRequest("Show delta exposure");
+        var rt  = mapper.readValue(mapper.writeValueAsString(req), DemoSemanticQueryRequest.class);
+        assertEquals(req.text(), rt.text());
+        assertNull(rt.limit());
+    }
+
+    @Test
+    void jacksonRoundTrip_filter_equality() throws Exception {
+        var f  = DemoSemanticFilter.eq("currency", "USD");
+        var rt = mapper.readValue(mapper.writeValueAsString(f), DemoSemanticFilter.class);
+        assertEquals("currency", rt.name());
+        assertEquals("USD",      rt.value());
+        assertNull(rt.operator());
+        assertNull(rt.values());
+    }
+
+    @Test
+    void jacksonRoundTrip_filter_in() throws Exception {
+        var f  = DemoSemanticFilter.in("currency", List.of("USD", "EUR"));
+        var rt = mapper.readValue(mapper.writeValueAsString(f), DemoSemanticFilter.class);
+        assertEquals("currency", rt.name());
+        assertEquals("IN",       rt.operator());
+        assertEquals(List.of("USD", "EUR"), rt.values());
+        assertNull(rt.value());
+    }
+
+    @Test
+    void jacksonRoundTrip_filter_between() throws Exception {
+        var f  = DemoSemanticFilter.between("cob_date", "2026-04-01", "2026-05-15");
+        var rt = mapper.readValue(mapper.writeValueAsString(f), DemoSemanticFilter.class);
+        assertEquals("BETWEEN",   rt.operator());
+        assertEquals("2026-04-01", rt.start());
+        assertEquals("2026-05-15", rt.end());
+        assertNull(rt.value());
+    }
+
+    @Test
+    void jacksonRoundTrip_interpretation_exposureGrid() throws Exception {
+        var interp = exposureGridInterpretation();
+        var json   = mapper.writeValueAsString(interp);
+        var rt     = mapper.readValue(json, DemoSemanticQueryInterpretation.class);
+        assertEquals(interp.contractId(),  rt.contractId());
+        assertEquals(interp.measure(),     rt.measure());
+        assertEquals(interp.groupBy(),     rt.groupBy());
+        assertEquals(interp.outputShape(), rt.outputShape());
+        assertEquals(interp.confidence(),  rt.confidence());
+        assertEquals(interp.filters().size(), rt.filters().size());
+    }
+
+    @Test
+    void jacksonRoundTrip_resultColumn() throws Exception {
+        var col = new DemoSemanticResultColumn("delta_exposure", "Delta Exposure", "DECIMAL", "MEASURE");
+        var rt  = mapper.readValue(mapper.writeValueAsString(col), DemoSemanticResultColumn.class);
+        assertEquals(col.name(),         rt.name());
+        assertEquals(col.displayName(),  rt.displayName());
+        assertEquals(col.dataType(),     rt.dataType());
+        assertEquals(col.semanticRole(), rt.semanticRole());
+    }
+
+    @Test
+    void jacksonRoundTrip_resultColumn_noRole() throws Exception {
+        var col = new DemoSemanticResultColumn("legal_entity", "Legal Entity", "STRING");
+        var rt  = mapper.readValue(mapper.writeValueAsString(col), DemoSemanticResultColumn.class);
+        assertNull(rt.semanticRole());
+    }
+
+    @Test
+    void jacksonRoundTrip_executionMetadata_completed() throws Exception {
+        var meta = new DemoSemanticExecutionMetadata(
+                GRID_CONTRACT, "q-001", null, 42L, 210L, ExecutionStatus.COMPLETED, null);
+        var rt   = mapper.readValue(mapper.writeValueAsString(meta), DemoSemanticExecutionMetadata.class);
+        assertEquals(meta.contractId(),      rt.contractId());
+        assertEquals(meta.queryId(),         rt.queryId());
+        assertEquals(meta.rowCount(),        rt.rowCount());
+        assertEquals(meta.executionStatus(), rt.executionStatus());
+        assertNull(rt.cacheStatus());
+        assertNull(rt.failureClassification());
+    }
+
+    @Test
+    void jacksonRoundTrip_executionResponse() throws Exception {
+        var resp = minimalGridResponse();
+        var json = mapper.writeValueAsString(resp);
+        var rt   = mapper.readValue(json, DemoSemanticQueryExecutionResponse.class);
+        assertEquals(resp.requestText(),               rt.requestText());
+        assertEquals(resp.interpretation().contractId(), rt.interpretation().contractId());
+        assertEquals(resp.metadata().rowCount(),       rt.metadata().rowCount());
+        assertEquals(resp.columns().size(),            rt.columns().size());
+        assertEquals(resp.rows().size(),               rt.rows().size());
+    }
+
+    // ── 4. Allowed validation outcome ─────────────────────────────────────────
+
+    @Test
+    void validation_allowed_integratesWithResponse() {
+        var validation = SemanticValidationOutcome.allowed(GRID_CONTRACT,
+                "delta_exposure by legal_entity and risk_class is permitted.");
+        var resp = new DemoSemanticQueryExecutionResponse(
+                "Show delta exposure for CIB",
+                exposureGridInterpretation(),
+                validation,
+                completedMetadata(GRID_CONTRACT, 10),
+                List.of(new DemoSemanticResultColumn("delta_exposure", "Delta Exposure", "DECIMAL", "MEASURE")),
+                List.of(Map.of("delta_exposure", 12345.67)));
+
+        assertTrue(resp.validation().allowed());
+        assertEquals(GRID_CONTRACT, resp.validation().contractId());
+        assertEquals(1, resp.rows().size());
+    }
+
+    // ── 5. Denied / unsupported / ambiguous outcomes ──────────────────────────
+
+    @Test
+    void confidence_unsupported_isNotExecutable() {
+        var interp = new DemoSemanticQueryInterpretation(
+                "What is the weather like today?",
+                null, null,
+                List.of(), List.of(),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.UNSUPPORTED,
+                List.of("No matching contract found for this request."));
+
+        assertFalse(interp.isExecutable());
+        assertNull(interp.contractId());
+        assertNull(interp.measure());
+        assertFalse(interp.warnings().isEmpty());
+    }
+
+    @Test
+    void confidence_ambiguous_isNotExecutable() {
+        var interp = new DemoSemanticQueryInterpretation(
+                "Show me risk",
+                GRID_CONTRACT, null,
+                List.of(), List.of(),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.AMBIGUOUS,
+                List.of("'risk' matches delta_exposure, dv01, vega, gamma — please be more specific."));
+
+        assertFalse(interp.isExecutable());
+    }
+
+    @Test
+    void validation_denied_unknownContract_representable() {
+        var outcome = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.UNKNOWN_CONTRACT,
+                "Contract 'foo' is not registered.");
+        assertFalse(outcome.allowed());
+        assertEquals(SemanticValidationReasonCode.UNKNOWN_CONTRACT, outcome.reasonCode());
+    }
+
+    @Test
+    void validation_denied_unsupportedOutputShape_representable() {
+        var outcome = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.UNSUPPORTED_OUTPUT_SHAPE,
+                "Output shape TIMESERIES is not supported by risk_sensitivity_exposure_grid.",
+                GRID_CONTRACT,
+                List.of("outputShape"));
+        assertFalse(outcome.allowed());
+        assertEquals(GRID_CONTRACT, outcome.contractId());
+    }
+
+    @Test
+    void validation_denied_ambiguousRequest_representable() {
+        var outcome = SemanticValidationOutcome.denied(
+                SemanticValidationReasonCode.AMBIGUOUS_REQUEST,
+                "The term 'risk' matches multiple measures. Please be more specific.");
+        assertFalse(outcome.allowed());
+        assertNull(outcome.contractId());
+    }
+
+    @Test
+    void confidence_allValues_representable() {
+        for (var c : DemoSemanticInterpretationConfidence.values()) {
+            assertNotNull(c.name());
+        }
+        var values = List.of(DemoSemanticInterpretationConfidence.values());
+        assertTrue(values.contains(DemoSemanticInterpretationConfidence.HIGH));
+        assertTrue(values.contains(DemoSemanticInterpretationConfidence.MEDIUM));
+        assertTrue(values.contains(DemoSemanticInterpretationConfidence.LOW));
+        assertTrue(values.contains(DemoSemanticInterpretationConfidence.UNSUPPORTED));
+        assertTrue(values.contains(DemoSemanticInterpretationConfidence.AMBIGUOUS));
+    }
+
+    // ── 6. Result metadata and result rows ────────────────────────────────────
+
+    @Test
+    void executionMetadata_completed_holdsFields() {
+        var meta = new DemoSemanticExecutionMetadata(
+                GRID_CONTRACT, "q-xyz", "ABSENT", 42L, 310L, ExecutionStatus.COMPLETED, null);
+        assertEquals(GRID_CONTRACT,           meta.contractId());
+        assertEquals("q-xyz",                 meta.queryId());
+        assertEquals("ABSENT",                meta.cacheStatus());
+        assertEquals(42L,                     meta.rowCount());
+        assertEquals(310L,                    meta.elapsedMs());
+        assertEquals(ExecutionStatus.COMPLETED, meta.executionStatus());
+        assertNull(meta.failureClassification());
+    }
+
+    @Test
+    void executionMetadata_cacheHit_holdsFields() {
+        var meta = new DemoSemanticExecutionMetadata(
+                TS_CONTRACT, "q-cache", "FRESH", 18L, null, ExecutionStatus.CACHE_HIT, null);
+        assertEquals(ExecutionStatus.CACHE_HIT, meta.executionStatus());
+        assertEquals("FRESH",                   meta.cacheStatus());
+        assertNull(meta.elapsedMs());
+    }
+
+    @Test
+    void executionMetadata_failed_holdsFailureClassification() {
+        var meta = new DemoSemanticExecutionMetadata(
+                GRID_CONTRACT, "q-fail", null, 0L, null,
+                ExecutionStatus.FAILED, SemanticExecutionFailure.UNAVAILABLE);
+        assertEquals(ExecutionStatus.FAILED,             meta.executionStatus());
+        assertEquals(SemanticExecutionFailure.UNAVAILABLE, meta.failureClassification());
+    }
+
+    @Test
+    void executionMetadata_failureClassification_rejectedWhenNotFailed() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new DemoSemanticExecutionMetadata(
+                        GRID_CONTRACT, "q-bad", null, 5L, null,
+                        ExecutionStatus.COMPLETED, SemanticExecutionFailure.TIMEOUT));
+    }
+
+    @Test
+    void resultRows_representMultipleRows() {
+        var rows = List.of(
+                Map.<String, Object>of("legal_entity", "CIB-US", "delta_exposure", 12345.67),
+                Map.<String, Object>of("legal_entity", "CIB-EU", "delta_exposure", 9876.54));
+        var resp = new DemoSemanticQueryExecutionResponse(
+                "Show delta exposure",
+                exposureGridInterpretation(),
+                SemanticValidationOutcome.allowed(GRID_CONTRACT, "OK"),
+                completedMetadata(GRID_CONTRACT, rows.size()),
+                List.of(new DemoSemanticResultColumn("legal_entity",   "Legal Entity",   "STRING",  "DIMENSION"),
+                        new DemoSemanticResultColumn("delta_exposure",  "Delta Exposure", "DECIMAL", "MEASURE")),
+                rows);
+
+        assertEquals(2, resp.rows().size());
+        assertEquals("CIB-US", resp.rows().get(0).get("legal_entity"));
+        assertEquals(9876.54,  resp.rows().get(1).get("delta_exposure"));
+    }
+
+    @Test
+    void resultRows_emptyList_safeForDeniedRequest() {
+        var resp = new DemoSemanticQueryExecutionResponse(
+                "What is the weather?",
+                new DemoSemanticQueryInterpretation(
+                        "What is the weather?",
+                        null, null,
+                        List.of(), List.of(),
+                        DemoSemanticOutputShape.GRID,
+                        DemoSemanticInterpretationConfidence.UNSUPPORTED,
+                        List.of("No matching contract.")),
+                SemanticValidationOutcome.denied(
+                        SemanticValidationReasonCode.UNSUPPORTED_REQUEST,
+                        "Request cannot be fulfilled by any demo contract."),
+                new DemoSemanticExecutionMetadata(
+                        "unknown", "q-noop", null, 0L, null, ExecutionStatus.FAILED,
+                        SemanticExecutionFailure.UNEXPECTED),
+                List.of(),
+                List.of());
+
+        assertFalse(resp.validation().allowed());
+        assertTrue(resp.columns().isEmpty());
+        assertTrue(resp.rows().isEmpty());
+    }
+
+    // ── 7. No raw SQL fields ───────────────────────────────────────────────────
+
+    @Test
+    void queryRequest_hasNoSqlField() throws Exception {
+        var req  = new DemoSemanticQueryRequest("Show delta exposure");
+        var json = mapper.writeValueAsString(req);
+        assertFalse(json.contains("sql"),    "request must not expose a sql field");
+        assertFalse(json.contains("SELECT"), "request must not expose SQL content");
+    }
+
+    @Test
+    void interpretation_hasNoSqlField() throws Exception {
+        var interp = exposureGridInterpretation();
+        var json   = mapper.writeValueAsString(interp);
+        assertFalse(json.contains("\"sql\""),    "interpretation must not expose a sql field");
+        assertFalse(json.contains("SELECT"),      "interpretation must not expose SQL content");
+    }
+
+    @Test
+    void executionResponse_hasNoSqlField() throws Exception {
+        var json = mapper.writeValueAsString(minimalGridResponse());
+        assertFalse(json.contains("\"sql\""),    "response must not expose a sql field");
+        assertFalse(json.contains("SELECT"),      "response must not expose SQL content");
+        assertFalse(json.contains("normalizedSql"), "response must not expose normalizedSql");
+    }
+
+    // ── Defensive copying ─────────────────────────────────────────────────────
+
+    @Test
+    void interpretation_groupBy_isUnmodifiable() {
+        var interp = exposureGridInterpretation();
+        assertThrows(UnsupportedOperationException.class, () -> interp.groupBy().add("extra"));
+    }
+
+    @Test
+    void interpretation_filters_isUnmodifiable() {
+        var interp = exposureGridInterpretation();
+        assertThrows(UnsupportedOperationException.class, () -> interp.filters().add(null));
+    }
+
+    @Test
+    void interpretation_warnings_isUnmodifiable() {
+        var interp = exposureGridInterpretation();
+        assertThrows(UnsupportedOperationException.class, () -> interp.warnings().add("extra"));
+    }
+
+    @Test
+    void response_columns_isUnmodifiable() {
+        var resp = minimalGridResponse();
+        assertThrows(UnsupportedOperationException.class, () -> resp.columns().add(null));
+    }
+
+    @Test
+    void response_rows_isUnmodifiable() {
+        var resp = minimalGridResponse();
+        assertThrows(UnsupportedOperationException.class, () -> resp.rows().add(null));
+    }
+
+    @Test
+    void filter_values_isUnmodifiable() {
+        var f = DemoSemanticFilter.in("currency", List.of("USD", "EUR"));
+        assertThrows(UnsupportedOperationException.class, () -> f.values().add("GBP"));
+    }
+
+    // ── Null / blank guard tests ───────────────────────────────────────────────
+
+    @Test
+    void queryRequest_rejectsNullText() {
+        assertThrows(NullPointerException.class, () -> new DemoSemanticQueryRequest(null));
+    }
+
+    @Test
+    void queryRequest_rejectsBlankText() {
+        assertThrows(IllegalArgumentException.class, () -> new DemoSemanticQueryRequest("  "));
+    }
+
+    @Test
+    void queryRequest_rejectsNonPositiveLimit() {
+        assertThrows(IllegalArgumentException.class, () -> new DemoSemanticQueryRequest("text", 0));
+        assertThrows(IllegalArgumentException.class, () -> new DemoSemanticQueryRequest("text", -1));
+    }
+
+    @Test
+    void filter_rejectsNullName() {
+        assertThrows(NullPointerException.class, () -> DemoSemanticFilter.eq(null, "val"));
+    }
+
+    @Test
+    void filter_rejectsBlankName() {
+        assertThrows(IllegalArgumentException.class, () -> DemoSemanticFilter.eq("", "val"));
+    }
+
+    @Test
+    void resultColumn_rejectsNullName() {
+        assertThrows(NullPointerException.class, () ->
+                new DemoSemanticResultColumn(null, "Display", "STRING"));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static DemoSemanticQueryInterpretation exposureGridInterpretation() {
+        return new DemoSemanticQueryInterpretation(
+                "Show me delta exposure by legal entity and risk class for CIB in USD as of 2026-05-15",
+                GRID_CONTRACT,
+                "delta_exposure",
+                List.of("legal_entity", "risk_class"),
+                List.of(
+                        DemoSemanticFilter.eq("org",      "CIB"),
+                        DemoSemanticFilter.eq("currency", "USD"),
+                        DemoSemanticFilter.eq("cob_date", "2026-05-15")),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.HIGH,
+                List.of());
+    }
+
+    private static DemoSemanticQueryInterpretation timeseriesInterpretation() {
+        return new DemoSemanticQueryInterpretation(
+                "Show dv01 trend by desk for CIB rates over the last 30 days",
+                TS_CONTRACT,
+                "dv01",
+                List.of("desk"),
+                List.of(
+                        DemoSemanticFilter.eq("org",        "CIB"),
+                        DemoSemanticFilter.eq("risk_class", "rates"),
+                        DemoSemanticFilter.eq("date_range", "last_30_days")),
+                DemoSemanticOutputShape.TIMESERIES,
+                DemoSemanticInterpretationConfidence.HIGH,
+                List.of());
+    }
+
+    private static DemoSemanticExecutionMetadata completedMetadata(String contractId, long rowCount) {
+        return new DemoSemanticExecutionMetadata(
+                contractId, "q-test", null, rowCount, 150L, ExecutionStatus.COMPLETED, null);
+    }
+
+    private DemoSemanticQueryExecutionResponse minimalGridResponse() {
+        return new DemoSemanticQueryExecutionResponse(
+                "Show delta exposure by legal entity for CIB USD as of 2026-05-15",
+                exposureGridInterpretation(),
+                SemanticValidationOutcome.allowed(GRID_CONTRACT, "Request is permitted."),
+                completedMetadata(GRID_CONTRACT, 2),
+                List.of(
+                        new DemoSemanticResultColumn("legal_entity",  "Legal Entity",   "STRING",  "DIMENSION"),
+                        new DemoSemanticResultColumn("delta_exposure", "Delta Exposure", "DECIMAL", "MEASURE")),
+                List.of(
+                        Map.of("legal_entity", "CIB-US", "delta_exposure", 12345.67),
+                        Map.of("legal_entity", "CIB-EU", "delta_exposure", 9876.54)));
+    }
+}

--- a/skadi-semantic/src/test/resources/fixtures/demo-contract-risk-sensitivity-exposure-grid.json
+++ b/skadi-semantic/src/test/resources/fixtures/demo-contract-risk-sensitivity-exposure-grid.json
@@ -1,0 +1,126 @@
+{
+  "name": "risk_sensitivity_exposure_grid",
+  "version": {
+    "value": "1.0.0"
+  },
+  "description": "Market-risk sensitivity exposure grid — governed grouped daily Greek exposure across risk dimensions. Supports grid-style querying: group by desk, risk_class, risk_factor, currency, or legal_entity. Demo spike fixture for issue #122 / epic #121.",
+  "entity": {
+    "name": "risk_sensitivity_exposure_grid",
+    "description": "Market-risk sensitivity exposure grid entity. Grain: one row per (cob_date, legal_entity, business_unit, desk, risk_class, risk_factor, currency, product). Output shape: tabular grid — each row is a sensitivity exposure cell. Demo placeholder — source view key: skadi.semantic.demo.exposure-view. TODO (follow-up story): wire endpoint to a config-driven source view key rather than hardcoded table coordinates.",
+    "endpoint": {
+      "catalog": "demo",
+      "schema": "market_risk",
+      "table": "sensitivity_exposure_v"
+    },
+    "ruleRefs": []
+  },
+  "measures": [
+    {
+      "name": "delta_exposure",
+      "label": "Delta Exposure",
+      "expression": "SUM(delta_exposure)",
+      "type": "DECIMAL",
+      "description": "Net delta sensitivity exposure aggregated across positions. Measures first-order sensitivity of portfolio value to changes in the underlying risk factor. Intended for risk monitoring and regulatory reporting. Aggregation: SUM."
+    },
+    {
+      "name": "dv01",
+      "label": "DV01",
+      "expression": "SUM(dv01)",
+      "type": "DECIMAL",
+      "description": "Dollar value of a basis point — interest rate sensitivity measure. Quantifies the change in position value for a one-basis-point parallel shift in the yield curve. Applicable to interest-rate-sensitive positions. Aggregation: SUM."
+    },
+    {
+      "name": "vega",
+      "label": "Vega",
+      "expression": "SUM(vega)",
+      "type": "DECIMAL",
+      "description": "Sensitivity of option portfolio value to changes in implied volatility. Applicable to positions with optionality. Caveat: vega is meaningful only where volatility surface coverage exists for the risk_factor. Aggregation: SUM."
+    },
+    {
+      "name": "gamma",
+      "label": "Gamma",
+      "expression": "SUM(gamma)",
+      "type": "DECIMAL",
+      "description": "Second-order delta sensitivity — rate of change of delta with respect to the underlying price. Applicable to non-linear positions. Caveat: gamma aggregation is directional and may obscure offsetting exposures. Aggregation: SUM."
+    }
+  ],
+  "dimensions": [
+    {
+      "name": "cob_date",
+      "column": "cob_date",
+      "type": "DATE",
+      "label": "Close of Business Date",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "legal_entity",
+      "column": "legal_entity",
+      "type": "STRING",
+      "label": "Legal Entity",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "business_unit",
+      "column": "business_unit",
+      "type": "STRING",
+      "label": "Business Unit",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "desk",
+      "column": "desk",
+      "type": "STRING",
+      "label": "Trading Desk",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "risk_class",
+      "column": "risk_class",
+      "type": "STRING",
+      "label": "Risk Class",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "risk_factor",
+      "column": "risk_factor",
+      "type": "STRING",
+      "label": "Risk Factor",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "currency",
+      "column": "currency",
+      "type": "STRING",
+      "label": "Currency",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "product",
+      "column": "product",
+      "type": "STRING",
+      "label": "Product",
+      "filterable": true,
+      "groupable": false
+    }
+  ],
+  "accessPolicy": {
+    "allowedRoles": [
+      {"name": "risk_analyst"},
+      {"name": "risk_viewer"}
+    ],
+    "allowedPrincipals": [],
+    "ruleRefs": []
+  },
+  "cachePolicy": {
+    "strategy": "TTL",
+    "ttlSeconds": 3600,
+    "ruleRefs": []
+  }
+}

--- a/skadi-semantic/src/test/resources/fixtures/demo-contract-risk-sensitivity-historical-timeseries.json
+++ b/skadi-semantic/src/test/resources/fixtures/demo-contract-risk-sensitivity-historical-timeseries.json
@@ -1,0 +1,126 @@
+{
+  "name": "risk_sensitivity_historical_timeseries",
+  "version": {
+    "value": "1.0.0"
+  },
+  "description": "Market-risk sensitivity historical time-series — governed daily Greek evolution across risk dimensions. Supports date/time-series grouped historical analysis: trend by cob_date grouped by desk or risk_class. Demo spike fixture for issue #122 / epic #121.",
+  "entity": {
+    "name": "risk_sensitivity_historical_timeseries",
+    "description": "Market-risk sensitivity historical time-series entity. Grain: one row per (cob_date, legal_entity, business_unit, desk, risk_class, risk_factor, currency). Output shape: time-series — ordered by cob_date, one sensitivity observation per time point and grouping key. Demo placeholder — source view key: skadi.semantic.demo.history-view. TODO (follow-up story): wire endpoint to a config-driven source view key rather than hardcoded table coordinates.",
+    "endpoint": {
+      "catalog": "demo",
+      "schema": "market_risk",
+      "table": "sensitivity_history_v"
+    },
+    "ruleRefs": []
+  },
+  "measures": [
+    {
+      "name": "delta_exposure",
+      "label": "Delta Exposure",
+      "expression": "SUM(delta_exposure)",
+      "type": "DECIMAL",
+      "description": "Net delta sensitivity exposure aggregated across positions for the given time point. Measures first-order sensitivity of portfolio value to changes in the underlying risk factor. Intended for historical risk trend analysis. Aggregation: SUM."
+    },
+    {
+      "name": "dv01",
+      "label": "DV01",
+      "expression": "SUM(dv01)",
+      "type": "DECIMAL",
+      "description": "Dollar value of a basis point — historical interest rate sensitivity. Quantifies the change in position value for a one-basis-point parallel shift at each historical COB date. Aggregation: SUM."
+    },
+    {
+      "name": "vega",
+      "label": "Vega",
+      "expression": "SUM(vega)",
+      "type": "DECIMAL",
+      "description": "Historical sensitivity of option portfolio value to changes in implied volatility. Tracks vega evolution over time. Caveat: applicable only to positions with optionality; zero elsewhere. Aggregation: SUM."
+    },
+    {
+      "name": "gamma",
+      "label": "Gamma",
+      "expression": "SUM(gamma)",
+      "type": "DECIMAL",
+      "description": "Historical second-order delta sensitivity over time. Tracks gamma evolution across COB dates. Caveat: gamma aggregation is directional and may obscure offsetting non-linear exposures. Aggregation: SUM."
+    }
+  ],
+  "dimensions": [
+    {
+      "name": "cob_date",
+      "column": "cob_date",
+      "type": "DATE",
+      "label": "Close of Business Date",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "legal_entity",
+      "column": "legal_entity",
+      "type": "STRING",
+      "label": "Legal Entity",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "business_unit",
+      "column": "business_unit",
+      "type": "STRING",
+      "label": "Business Unit",
+      "filterable": true,
+      "groupable": false
+    },
+    {
+      "name": "desk",
+      "column": "desk",
+      "type": "STRING",
+      "label": "Trading Desk",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "risk_class",
+      "column": "risk_class",
+      "type": "STRING",
+      "label": "Risk Class",
+      "filterable": true,
+      "groupable": true
+    },
+    {
+      "name": "risk_factor",
+      "column": "risk_factor",
+      "type": "STRING",
+      "label": "Risk Factor",
+      "filterable": true,
+      "groupable": false
+    },
+    {
+      "name": "currency",
+      "column": "currency",
+      "type": "STRING",
+      "label": "Currency",
+      "filterable": true,
+      "groupable": false
+    },
+    {
+      "name": "product",
+      "column": "product",
+      "type": "STRING",
+      "label": "Product",
+      "filterable": false,
+      "groupable": false
+    }
+  ],
+  "accessPolicy": {
+    "allowedRoles": [
+      {"name": "risk_analyst"},
+      {"name": "risk_viewer"}
+    ],
+    "allowedPrincipals": [],
+    "ruleRefs": []
+  },
+  "cachePolicy": {
+    "strategy": "TTL",
+    "ttlSeconds": 3600,
+    "ruleRefs": []
+  }
+}


### PR DESCRIPTION
## Closes

Closes #123

## Summary

- Adds `org.iceforge.skadi.semantic.demo` package with 8 new Java records/enums and a `package-info.java`
- **`DemoSemanticQueryRequest`** — plain-text inbound DTO (`text`, optional `limit`)
- **`DemoSemanticQueryInterpretation`** — interpreter output (`contractId`, `measure`, `groupBy`, `filters`, `outputShape`, `confidence`, `warnings`); includes `isExecutable()` guard
- **`DemoSemanticFilter`** — per-criterion filter record with static factories for equality, IN, and date-range forms; defensive list copy
- **`DemoSemanticOutputShape`** — enum `GRID` / `TIMESERIES`
- **`DemoSemanticInterpretationConfidence`** — enum `HIGH` / `MEDIUM` / `LOW` / `UNSUPPORTED` / `AMBIGUOUS`
- **`DemoSemanticExecutionMetadata`** — execution metadata reusing existing `ExecutionStatus` and `SemanticExecutionFailure`; enforces `failureClassification` is null unless status is FAILED
- **`DemoSemanticResultColumn`** — column descriptor (`name`, `displayName`, `dataType`, optional `semanticRole`)
- **`DemoSemanticQueryExecutionResponse`** — full response carrying interpretation, `SemanticValidationOutcome`, metadata, columns, and `List<Map<String, Object>>` rows

All records use `@JsonInclude(NON_NULL)`, defensive list copying, and null/blank guards consistent with the existing `skadi-semantic` style.

## Tests run

```
./mvnw test -pl skadi-semantic -Dtest=DemoSemanticQueryDtoTest
Tests run: 46, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

./mvnw verify -pl skadi-semantic
Tests run: 640, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

Test coverage includes:
- Exposure-grid and time-series request/interpretation representation
- Jackson serialization/deserialization round-trips for all DTO types
- Allowed validation outcome integrated with response
- UNSUPPORTED and AMBIGUOUS `isExecutable()` guard
- All denial reason codes representable
- Execution metadata for COMPLETED, CACHE_HIT, and FAILED status
- Multi-row result payloads
- Empty columns/rows for denied requests
- Defensive copy (unmodifiable list assertions)
- Null and blank guards

## Guardrail statement

No natural-language interpretation, SQL rendering, query execution, LLM integration, Databricks calls, or `skadi-sql-gateway` changes were introduced in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)