### PR TITLE
feat: add demo semantic intent adapter

### DIFF
--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticIntentAdapter.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticIntentAdapter.java
@@ -1,0 +1,31 @@
+package org.iceforge.skadi.semantic.demo;
+
+/**
+ * Translates a plain-English {@link DemoSemanticQueryRequest} into a structured
+ * {@link DemoSemanticQueryInterpretation}.
+ *
+ * <p>Implementations must:
+ * <ul>
+ *   <li>Never return {@code null} from {@link #interpret}.</li>
+ *   <li>Never generate SQL, call Databricks, call S3, or execute queries.</li>
+ *   <li>Return {@link DemoSemanticInterpretationConfidence#UNSUPPORTED} for
+ *       requests that cannot be mapped to a known demo contract.</li>
+ *   <li>Return {@link DemoSemanticInterpretationConfidence#AMBIGUOUS} for requests
+ *       that appear financial but cannot be resolved to a single interpretation.</li>
+ * </ul>
+ *
+ * <p>The canonical demo implementation is
+ * {@link RuleBasedDemoSemanticIntentAdapter}, which uses deterministic rule
+ * matching without any LLM or network calls.
+ */
+@FunctionalInterface
+public interface DemoSemanticIntentAdapter {
+
+    /**
+     * Interprets {@code request} and returns a structured representation of the intent.
+     *
+     * @param request the plain-English query request; must not be null
+     * @return the interpretation; never null
+     */
+    DemoSemanticQueryInterpretation interpret(DemoSemanticQueryRequest request);
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/RuleBasedDemoSemanticIntentAdapter.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/RuleBasedDemoSemanticIntentAdapter.java
@@ -1,0 +1,268 @@
+package org.iceforge.skadi.semantic.demo;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Deterministic rule-based implementation of {@link DemoSemanticIntentAdapter}.
+ *
+ * <p>Uses normalized-string matching and simple regex rules to map a small set
+ * of approved demo prompts to structured {@link DemoSemanticQueryInterpretation}
+ * records. No LLM, no network, no SQL generation.
+ *
+ * <p>Supported measures: {@code delta_exposure}, {@code dv01}, {@code vega},
+ * {@code gamma}. Supported grouping dimensions: {@code desk}, {@code legal_entity},
+ * {@code risk_class}, {@code risk_factor}, {@code currency}. Supported contracts:
+ * {@code risk_sensitivity_exposure_grid} (GRID) and
+ * {@code risk_sensitivity_historical_timeseries} (TIMESERIES).
+ *
+ * <p>Unknown prompts receive confidence {@link DemoSemanticInterpretationConfidence#UNSUPPORTED}.
+ * Prompts with financial keywords but no resolvable measure receive
+ * {@link DemoSemanticInterpretationConfidence#AMBIGUOUS}.
+ *
+ * <pre>{@code
+ * DemoSemanticIntentAdapter adapter = RuleBasedDemoSemanticIntentAdapter.create();
+ *
+ * var req  = new DemoSemanticQueryRequest(
+ *     "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15");
+ * var interp = adapter.interpret(req);
+ * // interp.contractId()  == "risk_sensitivity_exposure_grid"
+ * // interp.measure()     == "delta_exposure"
+ * // interp.groupBy()     == ["legal_entity", "risk_class"]
+ * // interp.confidence()  == HIGH
+ * }</pre>
+ *
+ * <p>This class has no Spring dependencies and requires no external configuration.
+ */
+public final class RuleBasedDemoSemanticIntentAdapter implements DemoSemanticIntentAdapter {
+
+    // ── Contract names ─────────────────────────────────────────────────────────
+
+    private static final String GRID_CONTRACT = "risk_sensitivity_exposure_grid";
+    private static final String TS_CONTRACT   = "risk_sensitivity_historical_timeseries";
+
+    // ── Dimension mapping (insertion-ordered: longest phrases first to avoid partial matches) ─
+
+    private static final Map<String, String> DIMENSION_MAP;
+
+    static {
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("legal entity", "legal_entity");
+        m.put("risk class",   "risk_class");
+        m.put("risk factor",  "risk_factor");
+        m.put("desk",         "desk");
+        m.put("currency",     "currency");
+        DIMENSION_MAP = Map.copyOf(m);
+    }
+
+    // ── Regex patterns ─────────────────────────────────────────────────────────
+
+    /** Captures everything after "by" up to the first stop-word or end-of-string. */
+    private static final Pattern BY_SECTION = Pattern.compile(
+            "\\bby\\s+(.*?)(?=\\s+(?:for|on|over|in|with)\\b|$)");
+
+    /** Captures a calendar date following "on" or "as of". */
+    private static final Pattern DATE_FILTER = Pattern.compile(
+            "(?:on|as of)\\s+(\\d{4}-\\d{2}-\\d{2})");
+
+    // ── Factory ────────────────────────────────────────────────────────────────
+
+    private RuleBasedDemoSemanticIntentAdapter() {}
+
+    /**
+     * Returns a new rule-based intent adapter.
+     *
+     * <p>The instance is stateless and thread-safe; callers may share a single instance.
+     */
+    public static RuleBasedDemoSemanticIntentAdapter create() {
+        return new RuleBasedDemoSemanticIntentAdapter();
+    }
+
+    // ── DemoSemanticIntentAdapter ──────────────────────────────────────────────
+
+    /**
+     * Interprets {@code request} using rule-based matching.
+     *
+     * <p>The original {@link DemoSemanticQueryRequest#text()} is preserved verbatim in
+     * {@link DemoSemanticQueryInterpretation#originalText()}. Matching is
+     * case-insensitive and tolerant of minor punctuation differences.
+     *
+     * @param request the plain-English query request; must not be null
+     * @return the interpretation; never null; isExecutable() is false for
+     *         UNSUPPORTED and AMBIGUOUS confidence levels
+     */
+    @Override
+    public DemoSemanticQueryInterpretation interpret(DemoSemanticQueryRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        String original   = request.text();
+        String normalized = normalize(original);
+
+        boolean   timeseries = isTimeseries(normalized);
+        String    measure    = extractMeasure(normalized);
+        List<String>             groupBy = extractGroupBy(normalized);
+        List<DemoSemanticFilter> filters = extractFilters(normalized);
+
+        String                   contractId = timeseries ? TS_CONTRACT : GRID_CONTRACT;
+        DemoSemanticOutputShape  shape      = timeseries
+                ? DemoSemanticOutputShape.TIMESERIES
+                : DemoSemanticOutputShape.GRID;
+
+        // ── Confidence and warnings ────────────────────────────────────────────
+
+        if (measure == null) {
+            if (hasFinancialKeyword(normalized)) {
+                return new DemoSemanticQueryInterpretation(
+                        original, null, null, groupBy, filters, shape,
+                        DemoSemanticInterpretationConfidence.AMBIGUOUS,
+                        List.of("Cannot determine measure from request text. "
+                                + "Specify one of: delta_exposure, dv01, vega, gamma."));
+            }
+            return new DemoSemanticQueryInterpretation(
+                    original, null, null, List.of(), List.of(), shape,
+                    DemoSemanticInterpretationConfidence.UNSUPPORTED,
+                    List.of("Demo supports only market-risk sensitivity queries. "
+                            + "Supported measures: delta_exposure, dv01, vega, gamma."));
+        }
+
+        List<String> warnings = new ArrayList<>();
+        DemoSemanticInterpretationConfidence confidence;
+
+        if (groupBy.isEmpty()) {
+            confidence = DemoSemanticInterpretationConfidence.MEDIUM;
+            warnings.add("No grouping dimensions identified. "
+                    + "Specify grouping with 'by <dimension>'.");
+        } else {
+            confidence = DemoSemanticInterpretationConfidence.HIGH;
+        }
+
+        return new DemoSemanticQueryInterpretation(
+                original, contractId, measure, groupBy, filters, shape, confidence,
+                List.copyOf(warnings));
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────────
+
+    /** Lowercases, strips punctuation, and collapses whitespace. */
+    private static String normalize(String text) {
+        return text.toLowerCase(Locale.ROOT)
+                   .replaceAll("[.,!?;:'\"]+", " ")
+                   .replaceAll("\\s+", " ")
+                   .trim();
+    }
+
+    /**
+     * Returns {@code true} if the normalized text contains keywords that indicate
+     * a time-series (historical) query.
+     */
+    private static boolean isTimeseries(String n) {
+        return n.contains("history")
+                || n.contains("historical")
+                || n.contains("trend")
+                || n.contains("last 30 days")
+                || n.contains("over the last")
+                || n.contains("time series")
+                || n.contains("timeseries");
+    }
+
+    /**
+     * Extracts the measure name from the normalized text, or {@code null} when no
+     * recognized measure is found.
+     *
+     * <p>Priority: {@code delta_exposure} > {@code dv01} > {@code vega} > {@code gamma}.
+     */
+    private static String extractMeasure(String n) {
+        if (n.contains("delta exposure") || (n.contains("delta") && n.contains("exposure"))) {
+            return "delta_exposure";
+        }
+        if (n.contains("dv01")) {
+            return "dv01";
+        }
+        if (n.contains("vega")) {
+            return "vega";
+        }
+        if (n.contains("gamma")) {
+            return "gamma";
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the ordered list of group-by dimension column names from the normalized
+     * text. Returns an empty list when no "by &lt;dimension&gt;" clause is found.
+     *
+     * <p>Handles multi-dimension clauses such as "by desk and currency".
+     */
+    private static List<String> extractGroupBy(String n) {
+        Matcher m = BY_SECTION.matcher(n);
+        if (!m.find()) return List.of();
+
+        String   bySection = m.group(1).trim();
+        String[] parts     = bySection.split("\\s+and\\s+");
+
+        List<String> result = new ArrayList<>();
+        for (String part : parts) {
+            String col = DIMENSION_MAP.get(part.trim());
+            if (col != null) result.add(col);
+        }
+        return List.copyOf(result);
+    }
+
+    /**
+     * Extracts filter criteria from the normalized text.
+     *
+     * <p>Recognized filter patterns:
+     * <ul>
+     *   <li>{@code \bcib\b} → org=CIB</li>
+     *   <li>{@code \busd\b} → currency=USD</li>
+     *   <li>{@code \brates\b} → risk_class=rates</li>
+     *   <li>{@code on YYYY-MM-DD} or {@code as of YYYY-MM-DD} → cob_date=YYYY-MM-DD</li>
+     *   <li>{@code last 30 days} → date_range=last_30_days</li>
+     * </ul>
+     */
+    private static List<DemoSemanticFilter> extractFilters(String n) {
+        List<DemoSemanticFilter> filters = new ArrayList<>();
+
+        if (n.matches(".*\\bcib\\b.*")) {
+            filters.add(DemoSemanticFilter.eq("org", "CIB"));
+        }
+        if (n.matches(".*\\busd\\b.*")) {
+            filters.add(DemoSemanticFilter.eq("currency", "USD"));
+        }
+        if (n.matches(".*\\brates\\b.*")) {
+            filters.add(DemoSemanticFilter.eq("risk_class", "rates"));
+        }
+
+        Matcher dm = DATE_FILTER.matcher(n);
+        if (dm.find()) {
+            filters.add(DemoSemanticFilter.eq("cob_date", dm.group(1)));
+        }
+
+        if (n.contains("last 30 days")) {
+            filters.add(DemoSemanticFilter.eq("date_range", "last_30_days"));
+        }
+
+        return List.copyOf(filters);
+    }
+
+    /**
+     * Returns {@code true} if the normalized text contains at least one recognized
+     * financial keyword, indicating the prompt is financial in intent but may be
+     * ambiguous rather than completely unrelated.
+     */
+    private static boolean hasFinancialKeyword(String n) {
+        return n.contains("delta")
+                || n.contains("dv01")
+                || n.contains("vega")
+                || n.contains("gamma")
+                || n.contains("exposure")
+                || n.contains("sensitivity")
+                || n.contains("greek");
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/package-info.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/package-info.java
@@ -1,14 +1,15 @@
 /**
  * Demo semantic query DTOs for the market-risk sensitivity plain-English demo.
  *
- * <p>This package contains the request/response model types that carry an
- * interpreted plain-English query through validation, future SQL-template
- * rendering, execution, and result return. It does not implement the interpreter,
- * SQL renderer, or any execution logic.
+ * <p>This package contains the request/response model types and the plain-English
+ * intent adapter for the market-risk sensitivity demo spike. It does not implement
+ * SQL rendering, query execution, or LLM integration.
  *
  * <p>Entry points:
  * <ul>
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticQueryRequest} — plain-text input</li>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticIntentAdapter} — interpreter interface</li>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.RuleBasedDemoSemanticIntentAdapter} — deterministic rule-based implementation</li>
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticQueryInterpretation} — interpreter output</li>
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticQueryExecutionResponse} — full execution response</li>
  * </ul>

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/demo/DemoSemanticIntentAdapterTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/demo/DemoSemanticIntentAdapterTest.java
@@ -1,0 +1,410 @@
+package org.iceforge.skadi.semantic.demo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link RuleBasedDemoSemanticIntentAdapter}.
+ *
+ * <p>Covers issue #124 definition-of-done criteria: all 6 required demo prompts
+ * map to correct structured interpretations, case/punctuation tolerance,
+ * unsupported and ambiguous prompts fail safely, and no SQL is returned.
+ *
+ * <p>No Spring context, no Databricks, no S3, no network calls,
+ * no skadi-sql-gateway changes.
+ */
+class DemoSemanticIntentAdapterTest {
+
+    private static final String GRID_CONTRACT = "risk_sensitivity_exposure_grid";
+    private static final String TS_CONTRACT   = "risk_sensitivity_historical_timeseries";
+
+    private DemoSemanticIntentAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = RuleBasedDemoSemanticIntentAdapter.create();
+    }
+
+    // ── 1. Exposure-grid prompt: delta by legal entity and risk class ──────────
+
+    @Test
+    void prompt1_deltaExposure_byLegalEntityAndRiskClass_mapsToGrid() {
+        var req    = req("Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15");
+        var interp = adapter.interpret(req);
+
+        assertEquals(GRID_CONTRACT,                              interp.contractId());
+        assertEquals("delta_exposure",                          interp.measure());
+        assertEquals(List.of("legal_entity", "risk_class"),     interp.groupBy());
+        assertEquals(DemoSemanticOutputShape.GRID,              interp.outputShape());
+        assertEquals(DemoSemanticInterpretationConfidence.HIGH, interp.confidence());
+        assertTrue(interp.isExecutable());
+    }
+
+    @Test
+    void prompt1_filters_orgCurrencyDate() {
+        var interp = adapter.interpret(req(
+                "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15"));
+
+        assertEquals(3, interp.filters().size());
+        assertFilter(interp, "org",      "CIB");
+        assertFilter(interp, "currency", "USD");
+        assertFilter(interp, "cob_date", "2026-05-15");
+    }
+
+    // ── 2. Time-series prompt: last 30 days rates DV01 by desk ────────────────
+
+    @Test
+    void prompt2_last30DaysRatesDv01_byDesk_mapsToTimeseries() {
+        var req    = req("Show the last 30 days of rates DV01 by desk for CIB");
+        var interp = adapter.interpret(req);
+
+        assertEquals(TS_CONTRACT,                               interp.contractId());
+        assertEquals("dv01",                                    interp.measure());
+        assertEquals(List.of("desk"),                           interp.groupBy());
+        assertEquals(DemoSemanticOutputShape.TIMESERIES,        interp.outputShape());
+        assertEquals(DemoSemanticInterpretationConfidence.HIGH, interp.confidence());
+        assertTrue(interp.isExecutable());
+    }
+
+    @Test
+    void prompt2_filters_orgRatesDateRange() {
+        var interp = adapter.interpret(req("Show the last 30 days of rates DV01 by desk for CIB"));
+
+        assertEquals(3, interp.filters().size());
+        assertFilter(interp, "org",        "CIB");
+        assertFilter(interp, "risk_class", "rates");
+        assertFilter(interp, "date_range", "last_30_days");
+    }
+
+    // ── 3. Exposure-grid prompt: vega by risk factor ──────────────────────────
+
+    @Test
+    void prompt3_vegaExposure_byRiskFactor_mapsToGrid() {
+        var req    = req("Show vega exposure by risk factor for CIB on 2026-05-15");
+        var interp = adapter.interpret(req);
+
+        assertEquals(GRID_CONTRACT,                              interp.contractId());
+        assertEquals("vega",                                     interp.measure());
+        assertEquals(List.of("risk_factor"),                     interp.groupBy());
+        assertEquals(DemoSemanticOutputShape.GRID,               interp.outputShape());
+        assertEquals(DemoSemanticInterpretationConfidence.HIGH,  interp.confidence());
+        assertTrue(interp.isExecutable());
+    }
+
+    @Test
+    void prompt3_filters_orgDate() {
+        var interp = adapter.interpret(req("Show vega exposure by risk factor for CIB on 2026-05-15"));
+        assertEquals(2, interp.filters().size());
+        assertFilter(interp, "org",      "CIB");
+        assertFilter(interp, "cob_date", "2026-05-15");
+    }
+
+    // ── 4. Exposure-grid prompt: gamma by desk and currency ───────────────────
+
+    @Test
+    void prompt4_gammaExposure_byDeskAndCurrency_mapsToGrid() {
+        var req    = req("Show gamma exposure by desk and currency for CIB on 2026-05-15");
+        var interp = adapter.interpret(req);
+
+        assertEquals(GRID_CONTRACT,                              interp.contractId());
+        assertEquals("gamma",                                    interp.measure());
+        assertEquals(List.of("desk", "currency"),                interp.groupBy());
+        assertEquals(DemoSemanticOutputShape.GRID,               interp.outputShape());
+        assertEquals(DemoSemanticInterpretationConfidence.HIGH,  interp.confidence());
+        assertTrue(interp.isExecutable());
+    }
+
+    @Test
+    void prompt4_filters_orgDate_noCurrencyFilter() {
+        var interp = adapter.interpret(req("Show gamma exposure by desk and currency for CIB on 2026-05-15"));
+        assertEquals(2, interp.filters().size());
+        assertFilter(interp, "org",      "CIB");
+        assertFilter(interp, "cob_date", "2026-05-15");
+        // "currency" is a groupBy dimension here, not a filter value
+        assertTrue(interp.filters().stream().noneMatch(f -> f.name().equals("currency")));
+    }
+
+    // ── 5. Exposure-grid prompt: delta by desk ────────────────────────────────
+
+    @Test
+    void prompt5_deltaExposure_byDesk_mapsToGrid() {
+        var req    = req("Show delta exposure by desk for CIB on 2026-05-15");
+        var interp = adapter.interpret(req);
+
+        assertEquals(GRID_CONTRACT,                              interp.contractId());
+        assertEquals("delta_exposure",                          interp.measure());
+        assertEquals(List.of("desk"),                           interp.groupBy());
+        assertEquals(DemoSemanticOutputShape.GRID,              interp.outputShape());
+        assertEquals(DemoSemanticInterpretationConfidence.HIGH, interp.confidence());
+        assertTrue(interp.isExecutable());
+    }
+
+    // ── 6. Time-series prompt: rates DV01 history by desk ────────────────────
+
+    @Test
+    void prompt6_ratesDv01History_byDesk_mapsToTimeseries() {
+        var req    = req("Show rates DV01 history by desk for CIB over the last 30 days");
+        var interp = adapter.interpret(req);
+
+        assertEquals(TS_CONTRACT,                               interp.contractId());
+        assertEquals("dv01",                                    interp.measure());
+        assertEquals(List.of("desk"),                           interp.groupBy());
+        assertEquals(DemoSemanticOutputShape.TIMESERIES,        interp.outputShape());
+        assertEquals(DemoSemanticInterpretationConfidence.HIGH, interp.confidence());
+        assertTrue(interp.isExecutable());
+    }
+
+    @Test
+    void prompt6_filters_orgRatesDateRange() {
+        var interp = adapter.interpret(req("Show rates DV01 history by desk for CIB over the last 30 days"));
+        assertEquals(3, interp.filters().size());
+        assertFilter(interp, "org",        "CIB");
+        assertFilter(interp, "risk_class", "rates");
+        assertFilter(interp, "date_range", "last_30_days");
+    }
+
+    // ── Case insensitivity ────────────────────────────────────────────────────
+
+    @Test
+    void caseInsensitive_allCaps_mapsCorrectly() {
+        var interp = adapter.interpret(req(
+                "SHOW USD DELTA EXPOSURE BY LEGAL ENTITY AND RISK CLASS FOR CIB ON 2026-05-15"));
+
+        assertEquals(GRID_CONTRACT,    interp.contractId());
+        assertEquals("delta_exposure", interp.measure());
+        assertEquals(List.of("legal_entity", "risk_class"), interp.groupBy());
+        assertFilter(interp, "org",      "CIB");
+        assertFilter(interp, "currency", "USD");
+        assertFilter(interp, "cob_date", "2026-05-15");
+        assertTrue(interp.isExecutable());
+    }
+
+    @Test
+    void caseInsensitive_mixedCase_mapsCorrectly() {
+        var interp = adapter.interpret(req(
+                "Show Rates DV01 History by Desk for CIB over the Last 30 Days"));
+
+        assertEquals(TS_CONTRACT, interp.contractId());
+        assertEquals("dv01",      interp.measure());
+        assertEquals(List.of("desk"), interp.groupBy());
+        assertTrue(interp.isExecutable());
+    }
+
+    // ── Punctuation tolerance ─────────────────────────────────────────────────
+
+    @Test
+    void punctuation_trailingPeriod_mapsCorrectly() {
+        var interp = adapter.interpret(req(
+                "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15."));
+
+        assertEquals(GRID_CONTRACT,    interp.contractId());
+        assertEquals("delta_exposure", interp.measure());
+        assertFilter(interp, "cob_date", "2026-05-15");
+        assertTrue(interp.isExecutable());
+    }
+
+    @Test
+    void punctuation_commasInPrompt_mapsCorrectly() {
+        var interp = adapter.interpret(req(
+                "Show USD delta exposure, by legal entity and risk class, for CIB on 2026-05-15"));
+
+        assertEquals("delta_exposure", interp.measure());
+        assertEquals(List.of("legal_entity", "risk_class"), interp.groupBy());
+        assertTrue(interp.isExecutable());
+    }
+
+    @Test
+    void punctuation_questionMark_mapsCorrectly() {
+        var interp = adapter.interpret(req(
+                "Show vega exposure by risk factor for CIB on 2026-05-15?"));
+
+        assertEquals("vega", interp.measure());
+        assertTrue(interp.isExecutable());
+    }
+
+    // ── Unsupported prompt ────────────────────────────────────────────────────
+
+    @Test
+    void unsupported_genericPrompt_returnsUnsupported() {
+        var interp = adapter.interpret(req("Show me everything in the table"));
+
+        assertEquals(DemoSemanticInterpretationConfidence.UNSUPPORTED, interp.confidence());
+        assertFalse(interp.isExecutable());
+        assertNull(interp.contractId());
+        assertNull(interp.measure());
+    }
+
+    @Test
+    void unsupported_prompt_hasWarning() {
+        var interp = adapter.interpret(req("List all the data"));
+        assertFalse(interp.warnings().isEmpty());
+        assertTrue(interp.warnings().get(0).contains("Supported measures"));
+    }
+
+    @Test
+    void unsupported_emptyGroupByAndFilters_forNonFinancial() {
+        var interp = adapter.interpret(req("What is the weather today?"));
+        assertEquals(DemoSemanticInterpretationConfidence.UNSUPPORTED, interp.confidence());
+        assertTrue(interp.groupBy().isEmpty());
+        assertTrue(interp.filters().isEmpty());
+        assertFalse(interp.isExecutable());
+    }
+
+    // ── Ambiguous prompt ──────────────────────────────────────────────────────
+
+    @Test
+    void ambiguous_exposureWithoutMeasure_returnsAmbiguous() {
+        var interp = adapter.interpret(req("Show exposure"));
+
+        assertEquals(DemoSemanticInterpretationConfidence.AMBIGUOUS, interp.confidence());
+        assertFalse(interp.isExecutable());
+        assertNull(interp.contractId());
+        assertNull(interp.measure());
+    }
+
+    @Test
+    void ambiguous_prompt_hasWarning() {
+        var interp = adapter.interpret(req("Show exposure"));
+        assertFalse(interp.warnings().isEmpty());
+        assertTrue(interp.warnings().get(0).contains("delta_exposure"));
+    }
+
+    @Test
+    void ambiguous_deltaWithoutExposure_isNotResolved() {
+        // "delta" alone is not enough — must be paired with "exposure"
+        var interp = adapter.interpret(req("Show delta by desk for CIB on 2026-05-15"));
+        assertEquals(DemoSemanticInterpretationConfidence.AMBIGUOUS, interp.confidence());
+        assertFalse(interp.isExecutable());
+    }
+
+    @Test
+    void ambiguous_sensitivityKeyword_isNotUnsupported() {
+        // "sensitivity" is a financial keyword — should be AMBIGUOUS, not UNSUPPORTED
+        var interp = adapter.interpret(req("Show sensitivity for CIB"));
+        assertEquals(DemoSemanticInterpretationConfidence.AMBIGUOUS, interp.confidence());
+    }
+
+    // ── Medium confidence ─────────────────────────────────────────────────────
+
+    @Test
+    void medium_measureFoundButNoGroupBy_returnsMedium() {
+        var interp = adapter.interpret(req("Show delta exposure for CIB on 2026-05-15"));
+
+        assertEquals(DemoSemanticInterpretationConfidence.MEDIUM, interp.confidence());
+        assertEquals("delta_exposure", interp.measure());
+        assertTrue(interp.groupBy().isEmpty());
+        // isExecutable() is false because contractId+measure are present but groupBy is empty;
+        // the isExecutable() check in the DTO requires contractId != null && measure != null,
+        // which holds here — so MEDIUM with measure and contractId IS executable
+        assertTrue(interp.isExecutable());
+        assertFalse(interp.warnings().isEmpty());
+    }
+
+    // ── Original text preserved ───────────────────────────────────────────────
+
+    @Test
+    void originalText_isPreservedVerbatim() {
+        String text   = "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15";
+        var    interp = adapter.interpret(req(text));
+        assertEquals(text, interp.originalText());
+    }
+
+    @Test
+    void originalText_preservedEvenForUnsupported() {
+        String text   = "Show me everything";
+        var    interp = adapter.interpret(req(text));
+        assertEquals(text, interp.originalText());
+    }
+
+    // ── No SQL in returned DTOs ───────────────────────────────────────────────
+
+    @Test
+    void noSql_interpretationHasNoSqlFields() {
+        var interp = adapter.interpret(req(
+                "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15"));
+        // DemoSemanticQueryInterpretation has no sql field; verify none of the filter
+        // values contain SQL keywords
+        for (DemoSemanticFilter f : interp.filters()) {
+            assertFalse(f.value() != null && f.value().toUpperCase().contains("SELECT"),
+                    "filter value must not contain SQL: " + f.value());
+        }
+        assertNull(interp.measure() != null && interp.measure().contains("SELECT")
+                ? "SQL found in measure" : null);
+    }
+
+    @Test
+    void noSql_unsupportedInterpretationHasNoSql() {
+        var interp = adapter.interpret(req("Show me everything in the table"));
+        assertTrue(interp.filters().isEmpty());
+        // warnings are plain English, not SQL
+        for (String w : interp.warnings()) {
+            assertFalse(w.toUpperCase().contains("SELECT"), "warning must not contain SQL");
+        }
+    }
+
+    // ── Null guard ─────────────────────────────────────────────────────────────
+
+    @Test
+    void nullRequest_throws() {
+        assertThrows(NullPointerException.class, () -> adapter.interpret(null));
+    }
+
+    // ── Interface contract ────────────────────────────────────────────────────
+
+    @Test
+    void adapter_isInstanceOfInterface() {
+        assertInstanceOf(DemoSemanticIntentAdapter.class, adapter);
+    }
+
+    @Test
+    void adapter_neverReturnsNull() {
+        String[] prompts = {
+            "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15",
+            "Show the last 30 days of rates DV01 by desk for CIB",
+            "Show vega exposure by risk factor for CIB on 2026-05-15",
+            "Show gamma exposure by desk and currency for CIB on 2026-05-15",
+            "Show delta exposure by desk for CIB on 2026-05-15",
+            "Show rates DV01 history by desk for CIB over the last 30 days",
+            "Show me everything in the table",
+            "Show exposure"
+        };
+        for (String p : prompts) {
+            assertNotNull(adapter.interpret(req(p)), "interpret() must not return null for: " + p);
+        }
+    }
+
+    // ── All 6 required prompts: isExecutable() ────────────────────────────────
+
+    @Test
+    void allSixDemoPrompts_areExecutable() {
+        String[] supported = {
+            "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15",
+            "Show the last 30 days of rates DV01 by desk for CIB",
+            "Show vega exposure by risk factor for CIB on 2026-05-15",
+            "Show gamma exposure by desk and currency for CIB on 2026-05-15",
+            "Show delta exposure by desk for CIB on 2026-05-15",
+            "Show rates DV01 history by desk for CIB over the last 30 days"
+        };
+        for (String p : supported) {
+            var interp = adapter.interpret(req(p));
+            assertTrue(interp.isExecutable(),
+                    "prompt should be executable: " + p + " — confidence=" + interp.confidence());
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static DemoSemanticQueryRequest req(String text) {
+        return new DemoSemanticQueryRequest(text);
+    }
+
+    private static void assertFilter(DemoSemanticQueryInterpretation interp, String name, String value) {
+        assertTrue(interp.filters().stream()
+                .anyMatch(f -> f.name().equals(name) && value.equals(f.value())),
+                "expected filter " + name + "=" + value + " in " + interp.filters());
+    }
+}


### PR DESCRIPTION
## Closes

Closes #124

## Summary

Adds a deterministic plain-English intent adapter for the market-risk sensitivity demo spike.

**New files:**
- `DemoSemanticIntentAdapter` — `@FunctionalInterface` with `interpret(DemoSemanticQueryRequest) → DemoSemanticQueryInterpretation`
- `RuleBasedDemoSemanticIntentAdapter` — rule-based implementation; stateless, thread-safe, `create()` factory; no Spring, no LLM, no network
- `package-info.java` — updated to document the new entry points
- `DemoSemanticIntentAdapterTest` — 32 focused unit tests

## Supported prompts

| # | Prompt | Contract | Measure | Output shape |
|---|--------|----------|---------|--------------|
| 1 | Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15 | `risk_sensitivity_exposure_grid` | `delta_exposure` | GRID |
| 2 | Show the last 30 days of rates DV01 by desk for CIB | `risk_sensitivity_historical_timeseries` | `dv01` | TIMESERIES |
| 3 | Show vega exposure by risk factor for CIB on 2026-05-15 | `risk_sensitivity_exposure_grid` | `vega` | GRID |
| 4 | Show gamma exposure by desk and currency for CIB on 2026-05-15 | `risk_sensitivity_exposure_grid` | `gamma` | GRID |
| 5 | Show delta exposure by desk for CIB on 2026-05-15 | `risk_sensitivity_exposure_grid` | `delta_exposure` | GRID |
| 6 | Show rates DV01 history by desk for CIB over the last 30 days | `risk_sensitivity_historical_timeseries` | `dv01` | TIMESERIES |

Matching is case-insensitive and tolerant of minor punctuation differences. Unknown prompts return `UNSUPPORTED`; financial-but-ambiguous prompts (e.g. "Show exposure") return `AMBIGUOUS`.

## Tests run

```
./mvnw test -pl skadi-semantic -Dtest=DemoSemanticIntentAdapterTest
Tests run: 32, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

./mvnw verify -pl skadi-semantic
Tests run: 672, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

Test coverage includes all 6 required demo prompts, case/punctuation tolerance, UNSUPPORTED and AMBIGUOUS safe fallbacks, original text preservation, no-SQL assertion, null guard, and `isExecutable()` on all 6 demo prompts.

## Guardrail statement

No SQL rendering, query execution, Databricks calls, LLM integration, S3 calls, or `skadi-sql-gateway` changes were introduced in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)