### PR TITLE
feat: add demo semantic SQL renderer

### DIFF
--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticRenderedSql.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticRenderedSql.java
@@ -1,0 +1,58 @@
+package org.iceforge.skadi.semantic.demo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The output of {@link DemoSemanticSqlRenderer}: a whitelisted SQL string with
+ * named bind parameters and rendering metadata.
+ *
+ * <p>The SQL text uses {@code :param_name} placeholders for all variable values.
+ * No user-provided literal values appear in {@link #sql()} — they are held
+ * separately in {@link #params()} and must be bound via the executing framework's
+ * named-parameter mechanism before the statement is sent to the database.
+ *
+ * <p>This separation is the primary injection-safety guarantee of the renderer.
+ * Callers must never concatenate {@link #params()} values directly into SQL text.
+ *
+ * <pre>{@code
+ * // Safe usage — params are bound by the JDBC framework, not concatenated:
+ * DemoSemanticRenderedSql rendered = renderer.render(interpretation);
+ * namedJdbcTemplate.queryForList(rendered.sql(), rendered.params());
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DemoSemanticRenderedSql(
+        String sql,
+        Map<String, Object> params,
+        String contractId,
+        DemoSemanticOutputShape outputShape,
+        String measure,
+        List<String> groupBy,
+        String viewName) {
+
+    /**
+     * @param sql         SQL text with {@code :param_name} bind placeholders; must not be null or blank
+     * @param params      named bind parameters; must not be null; copied defensively (unmodifiable)
+     * @param contractId  the contract that was rendered; must not be null
+     * @param outputShape the output shape (GRID or TIMESERIES); must not be null
+     * @param measure     the selected measure column name; must not be null
+     * @param groupBy     the ordered group-by column names; must not be null; copied defensively
+     * @param viewName    the fully-qualified view name used in FROM; must not be null
+     */
+    public DemoSemanticRenderedSql {
+        Objects.requireNonNull(sql,         "sql must not be null");
+        Objects.requireNonNull(params,      "params must not be null");
+        Objects.requireNonNull(contractId,  "contractId must not be null");
+        Objects.requireNonNull(outputShape, "outputShape must not be null");
+        Objects.requireNonNull(measure,     "measure must not be null");
+        Objects.requireNonNull(groupBy,     "groupBy must not be null");
+        Objects.requireNonNull(viewName,    "viewName must not be null");
+        if (sql.isBlank()) throw new IllegalArgumentException("sql must not be blank");
+        params  = Map.copyOf(params);
+        groupBy = List.copyOf(groupBy);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlRenderException.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlRenderException.java
@@ -1,0 +1,23 @@
+package org.iceforge.skadi.semantic.demo;
+
+/**
+ * Thrown by {@link DemoSemanticSqlRenderer} when a {@link DemoSemanticQueryInterpretation}
+ * cannot be rendered into safe SQL.
+ *
+ * <p>Common causes:
+ * <ul>
+ *   <li>The interpretation is not executable (confidence UNSUPPORTED or AMBIGUOUS)</li>
+ *   <li>The contract ID is not on the renderer's allowlist</li>
+ *   <li>The measure, a groupBy dimension, or a filter name is not on the allowlist</li>
+ *   <li>The contract/output-shape combination is inconsistent</li>
+ * </ul>
+ *
+ * <p>The message is operator-safe: it names which field failed the allowlist check
+ * but does not contain raw SQL, credentials, or stack traces.
+ */
+public final class DemoSemanticSqlRenderException extends RuntimeException {
+
+    public DemoSemanticSqlRenderException(String message) {
+        super(message);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlRenderer.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlRenderer.java
@@ -1,0 +1,29 @@
+package org.iceforge.skadi.semantic.demo;
+
+/**
+ * Renders a structured {@link DemoSemanticQueryInterpretation} into a safe,
+ * whitelisted {@link DemoSemanticRenderedSql}.
+ *
+ * <p>Implementations must:
+ * <ul>
+ *   <li>Validate the interpretation against explicit allowlists before rendering.</li>
+ *   <li>Use {@code :param_name} bind placeholders in the SQL text — never concatenate
+ *       user-supplied filter values directly into the SQL string.</li>
+ *   <li>Throw {@link DemoSemanticSqlRenderException} for any non-renderable input.</li>
+ *   <li>Never execute queries, call Databricks, call S3, or generate arbitrary SQL.</li>
+ * </ul>
+ *
+ * <p>The canonical implementation is {@link WhitelistedDemoSemanticSqlRenderer}.
+ */
+public interface DemoSemanticSqlRenderer {
+
+    /**
+     * Renders {@code interpretation} into a whitelisted SQL object.
+     *
+     * @param interpretation the structured interpretation to render; must not be null
+     * @return the rendered SQL with named bind parameters; never null
+     * @throws DemoSemanticSqlRenderException if the interpretation fails any allowlist check
+     *         or is not executable
+     */
+    DemoSemanticRenderedSql render(DemoSemanticQueryInterpretation interpretation);
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoViewConfig.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoViewConfig.java
@@ -1,0 +1,54 @@
+package org.iceforge.skadi.semantic.demo;
+
+import java.util.Objects;
+
+/**
+ * View-name configuration for the market-risk sensitivity demo SQL renderer.
+ *
+ * <p>Carries the fully-qualified names of the two demo views:
+ * {@link #exposureView()} for GRID queries and {@link #historyView()} for
+ * TIMESERIES queries. These names are operator-controlled configuration, not
+ * user input, and are embedded directly into rendered SQL.
+ *
+ * <p>Default placeholders (safe, non-production):
+ * <ul>
+ *   <li>{@code demo.market_risk.v_sensitivity_exposure_demo}</li>
+ *   <li>{@code demo.market_risk.v_sensitivity_history_demo}</li>
+ * </ul>
+ *
+ * <pre>{@code
+ * // Use placeholder defaults for the demo spike
+ * DemoViewConfig config = DemoViewConfig.defaults();
+ *
+ * // Override for a specific environment
+ * DemoViewConfig config = new DemoViewConfig(
+ *     "dev.market_risk.v_exposure_demo",
+ *     "dev.market_risk.v_history_demo");
+ * }</pre>
+ */
+public record DemoViewConfig(String exposureView, String historyView) {
+
+    private static final String DEFAULT_EXPOSURE_VIEW =
+            "demo.market_risk.v_sensitivity_exposure_demo";
+    private static final String DEFAULT_HISTORY_VIEW  =
+            "demo.market_risk.v_sensitivity_history_demo";
+
+    /**
+     * @param exposureView fully-qualified view name for GRID queries; must not be null or blank
+     * @param historyView  fully-qualified view name for TIMESERIES queries; must not be null or blank
+     */
+    public DemoViewConfig {
+        Objects.requireNonNull(exposureView, "exposureView must not be null");
+        Objects.requireNonNull(historyView,  "historyView must not be null");
+        if (exposureView.isBlank()) throw new IllegalArgumentException("exposureView must not be blank");
+        if (historyView.isBlank())  throw new IllegalArgumentException("historyView must not be blank");
+    }
+
+    /**
+     * Returns the default demo view configuration using safe placeholder view names
+     * that do not point to confidential production tables.
+     */
+    public static DemoViewConfig defaults() {
+        return new DemoViewConfig(DEFAULT_EXPOSURE_VIEW, DEFAULT_HISTORY_VIEW);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/WhitelistedDemoSemanticSqlRenderer.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/WhitelistedDemoSemanticSqlRenderer.java
@@ -1,0 +1,333 @@
+package org.iceforge.skadi.semantic.demo;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Allowlist-gated implementation of {@link DemoSemanticSqlRenderer}.
+ *
+ * <p>Converts a {@link DemoSemanticQueryInterpretation} into a
+ * {@link DemoSemanticRenderedSql} using two fixed Skadi-owned SQL templates:
+ * one for the exposure-grid shape and one for the historical time-series shape.
+ *
+ * <h2>Safety guarantees</h2>
+ * <ul>
+ *   <li><b>Allowlists</b> — contracts, measures, dimensions, and filter names are each
+ *       validated against an explicit set before any SQL is assembled.</li>
+ *   <li><b>Bind parameters</b> — all filter values appear as {@code :param_name}
+ *       placeholders in the SQL text; the actual values are held in the
+ *       {@link DemoSemanticRenderedSql#params()} map. The SQL text never contains
+ *       raw user-supplied strings.</li>
+ *   <li><b>Configured view names</b> — FROM clauses reference views from
+ *       {@link DemoViewConfig}, which is operator-controlled, not user input.</li>
+ *   <li><b>No execution</b> — this class assembles strings only; it never opens a
+ *       JDBC connection, calls Databricks, or contacts S3.</li>
+ * </ul>
+ *
+ * <h2>Limit handling</h2>
+ * <p>The renderer applies a default row limit ({@value #DEFAULT_LIMIT}) capped at a
+ * hard maximum ({@value #MAX_LIMIT}). A custom default limit may be supplied at
+ * construction time and is silently capped at {@value #MAX_LIMIT}.
+ *
+ * <h2>Date range</h2>
+ * <p>A {@code date_range=last_30_days} filter expands to a
+ * {@code cob_date between :start_date and :end_date} clause. The dates are computed
+ * from the {@link Clock} supplied at construction — inject a fixed clock in tests for
+ * deterministic assertions.
+ *
+ * <pre>{@code
+ * Clock fixedClock = Clock.fixed(
+ *     LocalDate.of(2026, 5, 18).atStartOfDay(ZoneOffset.UTC).toInstant(),
+ *     ZoneOffset.UTC);
+ * DemoSemanticSqlRenderer renderer =
+ *     WhitelistedDemoSemanticSqlRenderer.create(DemoViewConfig.defaults(), fixedClock);
+ *
+ * DemoSemanticRenderedSql result = renderer.render(interpretation);
+ * // result.sql() contains only :param placeholders, never raw filter values
+ * // result.params() contains {"org": "CIB", "currency": "USD", ...}
+ * }</pre>
+ */
+public final class WhitelistedDemoSemanticSqlRenderer implements DemoSemanticSqlRenderer {
+
+    // ── Constants ─────────────────────────────────────────────────────────────
+
+    static final int DEFAULT_LIMIT = 500;
+    static final int MAX_LIMIT     = 5000;
+
+    private static final String GRID_CONTRACT = "risk_sensitivity_exposure_grid";
+    private static final String TS_CONTRACT   = "risk_sensitivity_historical_timeseries";
+
+    // ── Allowlists ─────────────────────────────────────────────────────────────
+
+    private static final Set<String> ALLOWED_CONTRACTS = Set.of(
+            GRID_CONTRACT,
+            TS_CONTRACT);
+
+    private static final Set<String> ALLOWED_MEASURES = Set.of(
+            "delta_exposure",
+            "dv01",
+            "vega",
+            "gamma");
+
+    private static final Set<String> ALLOWED_DIMENSIONS = Set.of(
+            "cob_date",
+            "legal_entity",
+            "business_unit",
+            "desk",
+            "risk_class",
+            "risk_factor",
+            "currency",
+            "product");
+
+    private static final Set<String> ALLOWED_FILTERS = Set.of(
+            "org",
+            "currency",
+            "cob_date",
+            "risk_class",
+            "date_range");
+
+    // ── Instance fields ────────────────────────────────────────────────────────
+
+    private final DemoViewConfig viewConfig;
+    private final Clock          clock;
+    private final int            effectiveLimit;
+
+    // ── Constructor ────────────────────────────────────────────────────────────
+
+    private WhitelistedDemoSemanticSqlRenderer(DemoViewConfig viewConfig, Clock clock,
+                                               int effectiveLimit) {
+        this.viewConfig     = Objects.requireNonNull(viewConfig, "viewConfig must not be null");
+        this.clock          = Objects.requireNonNull(clock,      "clock must not be null");
+        this.effectiveLimit = effectiveLimit;
+    }
+
+    // ── Factories ──────────────────────────────────────────────────────────────
+
+    /**
+     * Returns a renderer with the default limit ({@value #DEFAULT_LIMIT}).
+     *
+     * @param viewConfig the demo view names; must not be null
+     * @param clock      clock used for {@code date_range} computations; must not be null
+     */
+    public static WhitelistedDemoSemanticSqlRenderer create(DemoViewConfig viewConfig, Clock clock) {
+        return new WhitelistedDemoSemanticSqlRenderer(viewConfig, clock, DEFAULT_LIMIT);
+    }
+
+    /**
+     * Returns a renderer with a custom default limit, capped at {@value #MAX_LIMIT}.
+     *
+     * @param viewConfig   the demo view names; must not be null
+     * @param clock        clock used for {@code date_range} computations; must not be null
+     * @param defaultLimit desired default row limit; must be positive; silently capped at {@value #MAX_LIMIT}
+     * @throws IllegalArgumentException if {@code defaultLimit} is zero or negative
+     */
+    public static WhitelistedDemoSemanticSqlRenderer create(DemoViewConfig viewConfig, Clock clock,
+                                                            int defaultLimit) {
+        if (defaultLimit <= 0) {
+            throw new IllegalArgumentException(
+                    "defaultLimit must be positive, was: " + defaultLimit);
+        }
+        return new WhitelistedDemoSemanticSqlRenderer(
+                viewConfig, clock, Math.min(defaultLimit, MAX_LIMIT));
+    }
+
+    /**
+     * Returns a renderer backed by {@link DemoViewConfig#defaults()} and
+     * {@link Clock#systemDefaultZone()}.
+     *
+     * <p>Not suitable for tests that assert on date-range parameters — use
+     * {@link #create(DemoViewConfig, Clock)} with a fixed clock instead.
+     */
+    public static WhitelistedDemoSemanticSqlRenderer createWithDefaults() {
+        return create(DemoViewConfig.defaults(), Clock.systemDefaultZone());
+    }
+
+    // ── DemoSemanticSqlRenderer ────────────────────────────────────────────────
+
+    /**
+     * Renders {@code interpretation} into a whitelisted SQL object.
+     *
+     * @param interpretation the structured interpretation to render; must not be null
+     * @return rendered SQL with named bind parameters; never null
+     * @throws DemoSemanticSqlRenderException if any allowlist check fails or the
+     *         interpretation is not executable
+     */
+    @Override
+    public DemoSemanticRenderedSql render(DemoSemanticQueryInterpretation interpretation) {
+        Objects.requireNonNull(interpretation, "interpretation must not be null");
+
+        validate(interpretation);
+
+        return switch (interpretation.outputShape()) {
+            case GRID       -> renderGrid(interpretation);
+            case TIMESERIES -> renderTimeseries(interpretation);
+        };
+    }
+
+    // ── Validation ─────────────────────────────────────────────────────────────
+
+    private static void validate(DemoSemanticQueryInterpretation i) {
+        if (!i.isExecutable()) {
+            throw new DemoSemanticSqlRenderException(
+                    "interpretation is not executable (confidence=" + i.confidence() + ")");
+        }
+        if (!ALLOWED_CONTRACTS.contains(i.contractId())) {
+            throw new DemoSemanticSqlRenderException(
+                    "contract not on allowlist: '" + i.contractId() + "'");
+        }
+        if (!ALLOWED_MEASURES.contains(i.measure())) {
+            throw new DemoSemanticSqlRenderException(
+                    "measure not on allowlist: '" + i.measure() + "'");
+        }
+        for (String dim : i.groupBy()) {
+            if (!ALLOWED_DIMENSIONS.contains(dim)) {
+                throw new DemoSemanticSqlRenderException(
+                        "groupBy dimension not on allowlist: '" + dim + "'");
+            }
+        }
+        for (DemoSemanticFilter f : i.filters()) {
+            if (!ALLOWED_FILTERS.contains(f.name())) {
+                throw new DemoSemanticSqlRenderException(
+                        "filter name not on allowlist: '" + f.name() + "'");
+            }
+        }
+        if (GRID_CONTRACT.equals(i.contractId()) && i.outputShape() != DemoSemanticOutputShape.GRID) {
+            throw new DemoSemanticSqlRenderException(
+                    "contract '" + GRID_CONTRACT + "' requires outputShape GRID, got: " + i.outputShape());
+        }
+        if (TS_CONTRACT.equals(i.contractId()) && i.outputShape() != DemoSemanticOutputShape.TIMESERIES) {
+            throw new DemoSemanticSqlRenderException(
+                    "contract '" + TS_CONTRACT + "' requires outputShape TIMESERIES, got: " + i.outputShape());
+        }
+    }
+
+    // ── Grid rendering ─────────────────────────────────────────────────────────
+
+    /**
+     * Renders the exposure-grid SQL template.
+     *
+     * <pre>{@code
+     * select <groupBy cols>, sum(<measure>) as <measure>
+     * from <exposureView>
+     * where <filter col> = :<filter col> [and ...]
+     * group by <groupBy cols>
+     * order by <groupBy cols>
+     * limit :limit
+     * }</pre>
+     */
+    private DemoSemanticRenderedSql renderGrid(DemoSemanticQueryInterpretation i) {
+        String viewName    = viewConfig.exposureView();
+        String groupByCols = String.join(", ", i.groupBy());
+
+        Map<String, Object> params      = new LinkedHashMap<>();
+        List<String>        whereParts  = new ArrayList<>();
+
+        for (DemoSemanticFilter f : i.filters()) {
+            if ("date_range".equals(f.name())) {
+                // Expand to a between clause (hoisted, but for GRID just inline)
+                LocalDate end   = LocalDate.now(clock);
+                LocalDate start = end.minusDays(30);
+                whereParts.add("cob_date between :start_date and :end_date");
+                params.put("start_date", start.toString());
+                params.put("end_date",   end.toString());
+            } else {
+                whereParts.add(f.name() + " = :" + f.name());
+                params.put(f.name(), f.value());
+            }
+        }
+
+        params.put("limit", effectiveLimit);
+
+        StringBuilder sql = new StringBuilder();
+        sql.append("select ").append(groupByCols)
+           .append(", sum(").append(i.measure()).append(") as ").append(i.measure())
+           .append("\nfrom ").append(viewName);
+
+        if (!whereParts.isEmpty()) {
+            sql.append("\nwhere ").append(String.join(" and ", whereParts));
+        }
+
+        sql.append("\ngroup by ").append(groupByCols)
+           .append("\norder by ").append(groupByCols)
+           .append("\nlimit :limit");
+
+        return new DemoSemanticRenderedSql(
+                sql.toString(), params, i.contractId(), i.outputShape(), i.measure(), i.groupBy(),
+                viewName);
+    }
+
+    // ── Time-series rendering ──────────────────────────────────────────────────
+
+    /**
+     * Renders the historical time-series SQL template.
+     *
+     * <pre>{@code
+     * select cob_date, <groupBy cols>, sum(<measure>) as <measure>
+     * from <historyView>
+     * where cob_date between :start_date and :end_date
+     *   and <filter col> = :<filter col> [...]
+     * group by cob_date, <groupBy cols>
+     * order by cob_date, <groupBy cols>
+     * limit :limit
+     * }</pre>
+     *
+     * <p>The {@code date_range} filter is hoisted to the top of the WHERE clause and
+     * expanded to {@code cob_date between :start_date and :end_date}. All other filters
+     * follow as {@code and <name> = :<name>}.
+     */
+    private DemoSemanticRenderedSql renderTimeseries(DemoSemanticQueryInterpretation i) {
+        String viewName    = viewConfig.historyView();
+        String groupByCols = String.join(", ", i.groupBy());
+
+        Map<String, Object> params         = new LinkedHashMap<>();
+        List<String>        otherWhere     = new ArrayList<>();
+        boolean             hasDateRange   = false;
+
+        for (DemoSemanticFilter f : i.filters()) {
+            if ("date_range".equals(f.name())) {
+                hasDateRange = true;
+                LocalDate end   = LocalDate.now(clock);
+                LocalDate start = end.minusDays(30);
+                params.put("start_date", start.toString());
+                params.put("end_date",   end.toString());
+            } else {
+                otherWhere.add(f.name() + " = :" + f.name());
+                params.put(f.name(), f.value());
+            }
+        }
+
+        params.put("limit", effectiveLimit);
+
+        StringBuilder sql = new StringBuilder();
+        sql.append("select cob_date, ").append(groupByCols)
+           .append(", sum(").append(i.measure()).append(") as ").append(i.measure())
+           .append("\nfrom ").append(viewName);
+
+        if (hasDateRange) {
+            sql.append("\nwhere cob_date between :start_date and :end_date");
+            for (String clause : otherWhere) {
+                sql.append("\n  and ").append(clause);
+            }
+        } else if (!otherWhere.isEmpty()) {
+            sql.append("\nwhere ");
+            for (int idx = 0; idx < otherWhere.size(); idx++) {
+                if (idx > 0) sql.append("\n  and ");
+                sql.append(otherWhere.get(idx));
+            }
+        }
+
+        sql.append("\ngroup by cob_date, ").append(groupByCols)
+           .append("\norder by cob_date, ").append(groupByCols)
+           .append("\nlimit :limit");
+
+        return new DemoSemanticRenderedSql(
+                sql.toString(), params, i.contractId(), i.outputShape(), i.measure(), i.groupBy(),
+                viewName);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/package-info.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/package-info.java
@@ -11,6 +11,10 @@
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticIntentAdapter} — interpreter interface</li>
  *   <li>{@link org.iceforge.skadi.semantic.demo.RuleBasedDemoSemanticIntentAdapter} — deterministic rule-based implementation</li>
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticQueryInterpretation} — interpreter output</li>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticSqlRenderer} — SQL renderer interface</li>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.WhitelistedDemoSemanticSqlRenderer} — allowlist-gated SQL renderer</li>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticRenderedSql} — rendered SQL with bind params</li>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.DemoViewConfig} — operator-controlled view name config</li>
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticQueryExecutionResponse} — full execution response</li>
  * </ul>
  */

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlRendererTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlRendererTest.java
@@ -1,0 +1,538 @@
+package org.iceforge.skadi.semantic.demo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link WhitelistedDemoSemanticSqlRenderer}.
+ *
+ * <p>Covers issue #125 definition-of-done criteria: exposure-grid and time-series
+ * render paths, configured view names, allowlist rejections, limit handling,
+ * deterministic date expansion, and injection-safety via bind parameters.
+ *
+ * <p>No Spring context, no Databricks, no S3, no network calls,
+ * no skadi-sql-gateway changes.
+ */
+class DemoSemanticSqlRendererTest {
+
+    // Fixed clock at 2026-05-18 00:00 UTC — start_date = 2026-04-18, end_date = 2026-05-18
+    private static final LocalDate FIXED_DATE        = LocalDate.of(2026, 5, 18);
+    private static final LocalDate EXPECTED_START    = FIXED_DATE.minusDays(30); // 2026-04-18
+    private static final Clock     FIXED_CLOCK       = Clock.fixed(
+            FIXED_DATE.atStartOfDay(ZoneOffset.UTC).toInstant(), ZoneOffset.UTC);
+
+    private static final String GRID_CONTRACT  = "risk_sensitivity_exposure_grid";
+    private static final String TS_CONTRACT    = "risk_sensitivity_historical_timeseries";
+    private static final String EXPOSURE_VIEW  = "demo.market_risk.v_sensitivity_exposure_demo";
+    private static final String HISTORY_VIEW   = "demo.market_risk.v_sensitivity_history_demo";
+
+    private DemoSemanticSqlRenderer renderer;
+
+    @BeforeEach
+    void setUp() {
+        renderer = WhitelistedDemoSemanticSqlRenderer.create(DemoViewConfig.defaults(), FIXED_CLOCK);
+    }
+
+    // ── 1. Exposure-grid renders expected SQL shape and params ─────────────────
+
+    @Test
+    void grid_rendersSelectClause() {
+        var result = renderer.render(gridInterp());
+        String sql = result.sql();
+        assertTrue(sql.contains("select legal_entity, risk_class, sum(delta_exposure) as delta_exposure"),
+                "unexpected select clause: " + sql);
+    }
+
+    @Test
+    void grid_rendersFromClause() {
+        var result = renderer.render(gridInterp());
+        assertTrue(result.sql().contains("from " + EXPOSURE_VIEW));
+    }
+
+    @Test
+    void grid_rendersWhereClause_allFilters() {
+        var result = renderer.render(gridInterp());
+        String sql = result.sql();
+        assertTrue(sql.contains("where org = :org and currency = :currency and cob_date = :cob_date"),
+                "unexpected where clause: " + sql);
+    }
+
+    @Test
+    void grid_rendersGroupByAndOrderBy() {
+        var result = renderer.render(gridInterp());
+        String sql = result.sql();
+        assertTrue(sql.contains("group by legal_entity, risk_class"), sql);
+        assertTrue(sql.contains("order by legal_entity, risk_class"), sql);
+    }
+
+    @Test
+    void grid_rendersLimitPlaceholder() {
+        assertTrue(renderer.render(gridInterp()).sql().contains("limit :limit"));
+    }
+
+    @Test
+    void grid_params_containsExpectedValues() {
+        var params = renderer.render(gridInterp()).params();
+        assertEquals("CIB",        params.get("org"));
+        assertEquals("USD",        params.get("currency"));
+        assertEquals("2026-05-15", params.get("cob_date"));
+    }
+
+    @Test
+    void grid_params_limitIsDefault() {
+        assertEquals(WhitelistedDemoSemanticSqlRenderer.DEFAULT_LIMIT,
+                renderer.render(gridInterp()).params().get("limit"));
+    }
+
+    @Test
+    void grid_metadata_contractIdAndShape() {
+        var result = renderer.render(gridInterp());
+        assertEquals(GRID_CONTRACT,                result.contractId());
+        assertEquals(DemoSemanticOutputShape.GRID,  result.outputShape());
+        assertEquals("delta_exposure",             result.measure());
+        assertEquals(List.of("legal_entity", "risk_class"), result.groupBy());
+    }
+
+    // ── 2. Historical time-series renders expected SQL shape and params ─────────
+
+    @Test
+    void timeseries_rendersSelectWithCobDate() {
+        var result = renderer.render(tsInterp());
+        assertTrue(result.sql().contains("select cob_date, desk, sum(dv01) as dv01"),
+                result.sql());
+    }
+
+    @Test
+    void timeseries_rendersFromHistoryView() {
+        assertTrue(renderer.render(tsInterp()).sql().contains("from " + HISTORY_VIEW));
+    }
+
+    @Test
+    void timeseries_rendersDateRangeFirstInWhere() {
+        var result = renderer.render(tsInterp());
+        String sql = result.sql();
+        int dateRangeIdx = sql.indexOf("cob_date between :start_date and :end_date");
+        int orgIdx       = sql.indexOf("org = :org");
+        assertTrue(dateRangeIdx >= 0,  "date range not found: " + sql);
+        assertTrue(orgIdx >= 0,        "org filter not found: " + sql);
+        assertTrue(dateRangeIdx < orgIdx, "date range must precede org filter");
+    }
+
+    @Test
+    void timeseries_rendersOtherFiltersWithAnd() {
+        var result = renderer.render(tsInterp());
+        assertTrue(result.sql().contains("and org = :org"),        result.sql());
+        assertTrue(result.sql().contains("and risk_class = :risk_class"), result.sql());
+    }
+
+    @Test
+    void timeseries_rendersGroupByWithCobDate() {
+        assertTrue(renderer.render(tsInterp()).sql().contains("group by cob_date, desk"));
+    }
+
+    @Test
+    void timeseries_rendersOrderByWithCobDate() {
+        assertTrue(renderer.render(tsInterp()).sql().contains("order by cob_date, desk"));
+    }
+
+    @Test
+    void timeseries_params_containsExpectedValues() {
+        var params = renderer.render(tsInterp()).params();
+        assertEquals("CIB",   params.get("org"));
+        assertEquals("rates", params.get("risk_class"));
+    }
+
+    @Test
+    void timeseries_metadata_contractIdAndShape() {
+        var result = renderer.render(tsInterp());
+        assertEquals(TS_CONTRACT,                                      result.contractId());
+        assertEquals(DemoSemanticOutputShape.TIMESERIES,               result.outputShape());
+        assertEquals("dv01",                                           result.measure());
+        assertEquals(List.of("desk"),                                  result.groupBy());
+    }
+
+    // ── 3. Renderer uses configured exposure view for GRID ─────────────────────
+
+    @Test
+    void grid_viewName_isConfiguredExposureView() {
+        assertEquals(EXPOSURE_VIEW, renderer.render(gridInterp()).viewName());
+    }
+
+    @Test
+    void grid_customViewConfig_usedInSql() {
+        var customConfig = new DemoViewConfig("dev.risk.exposure_v", "dev.risk.history_v");
+        var customRenderer = WhitelistedDemoSemanticSqlRenderer.create(customConfig, FIXED_CLOCK);
+        assertTrue(customRenderer.render(gridInterp()).sql().contains("from dev.risk.exposure_v"));
+    }
+
+    // ── 4. Renderer uses configured history view for TIMESERIES ───────────────
+
+    @Test
+    void timeseries_viewName_isConfiguredHistoryView() {
+        assertEquals(HISTORY_VIEW, renderer.render(tsInterp()).viewName());
+    }
+
+    @Test
+    void timeseries_customViewConfig_usedInSql() {
+        var customConfig   = new DemoViewConfig("dev.risk.exposure_v", "dev.risk.history_v");
+        var customRenderer = WhitelistedDemoSemanticSqlRenderer.create(customConfig, FIXED_CLOCK);
+        assertTrue(customRenderer.render(tsInterp()).sql().contains("from dev.risk.history_v"));
+    }
+
+    // ── 5. Unknown contract is rejected ────────────────────────────────────────
+
+    @Test
+    void unknownContract_throws() {
+        var interp = interpWithContract("unknown_contract");
+        assertThrows(DemoSemanticSqlRenderException.class, () -> renderer.render(interp));
+    }
+
+    @Test
+    void unknownContract_messageNamesContract() {
+        var ex = assertThrows(DemoSemanticSqlRenderException.class,
+                () -> renderer.render(interpWithContract("bad_contract")));
+        assertTrue(ex.getMessage().contains("bad_contract"), ex.getMessage());
+    }
+
+    // ── 6. Non-executable interpretation is rejected ───────────────────────────
+
+    @Test
+    void unsupportedInterp_throws() {
+        assertThrows(DemoSemanticSqlRenderException.class,
+                () -> renderer.render(unsupportedInterp()));
+    }
+
+    @Test
+    void ambiguousInterp_throws() {
+        assertThrows(DemoSemanticSqlRenderException.class,
+                () -> renderer.render(ambiguousInterp()));
+    }
+
+    @Test
+    void nonExecutable_messageContainsConfidence() {
+        var ex = assertThrows(DemoSemanticSqlRenderException.class,
+                () -> renderer.render(unsupportedInterp()));
+        assertTrue(ex.getMessage().contains("UNSUPPORTED"), ex.getMessage());
+    }
+
+    // ── 7. Unknown measure is rejected ─────────────────────────────────────────
+
+    @Test
+    void unknownMeasure_throws() {
+        var interp = interpWithMeasure("net_pnl");
+        assertThrows(DemoSemanticSqlRenderException.class, () -> renderer.render(interp));
+    }
+
+    @Test
+    void unknownMeasure_messageNamesMeasure() {
+        var ex = assertThrows(DemoSemanticSqlRenderException.class,
+                () -> renderer.render(interpWithMeasure("bad_measure")));
+        assertTrue(ex.getMessage().contains("bad_measure"), ex.getMessage());
+    }
+
+    // ── 8. Unknown groupBy dimension is rejected ───────────────────────────────
+
+    @Test
+    void unknownGroupByDimension_throws() {
+        var interp = interpWithGroupBy(List.of("unknown_dim"));
+        assertThrows(DemoSemanticSqlRenderException.class, () -> renderer.render(interp));
+    }
+
+    @Test
+    void unknownGroupByDimension_messageNamesDimension() {
+        var ex = assertThrows(DemoSemanticSqlRenderException.class,
+                () -> renderer.render(interpWithGroupBy(List.of("secret_col"))));
+        assertTrue(ex.getMessage().contains("secret_col"), ex.getMessage());
+    }
+
+    // ── 9. Unknown filter is rejected ──────────────────────────────────────────
+
+    @Test
+    void unknownFilter_throws() {
+        var interp = interpWithExtraFilter("unknown_filter", "val");
+        assertThrows(DemoSemanticSqlRenderException.class, () -> renderer.render(interp));
+    }
+
+    @Test
+    void unknownFilter_messageNamesFilter() {
+        var ex = assertThrows(DemoSemanticSqlRenderException.class,
+                () -> renderer.render(interpWithExtraFilter("bad_filter", "val")));
+        assertTrue(ex.getMessage().contains("bad_filter"), ex.getMessage());
+    }
+
+    // ── 10. Contract/shape mismatch is rejected ────────────────────────────────
+
+    @Test
+    void gridContractWithTimeseriesShape_throws() {
+        var interp = new DemoSemanticQueryInterpretation(
+                "test", GRID_CONTRACT, "delta_exposure",
+                List.of("desk"), List.of(DemoSemanticFilter.eq("org", "CIB")),
+                DemoSemanticOutputShape.TIMESERIES,  // wrong shape for GRID contract
+                DemoSemanticInterpretationConfidence.HIGH, List.of());
+        assertThrows(DemoSemanticSqlRenderException.class, () -> renderer.render(interp));
+    }
+
+    @Test
+    void tsContractWithGridShape_throws() {
+        var interp = new DemoSemanticQueryInterpretation(
+                "test", TS_CONTRACT, "dv01",
+                List.of("desk"), List.of(DemoSemanticFilter.eq("org", "CIB")),
+                DemoSemanticOutputShape.GRID,  // wrong shape for TS contract
+                DemoSemanticInterpretationConfidence.HIGH, List.of());
+        assertThrows(DemoSemanticSqlRenderException.class, () -> renderer.render(interp));
+    }
+
+    // ── 11. date_range expands to deterministic start/end dates ───────────────
+
+    @Test
+    void timeseries_dateRange_startDateIsCorrect() {
+        var params = renderer.render(tsInterp()).params();
+        assertEquals(EXPECTED_START.toString(), params.get("start_date"),
+                "start_date should be 30 days before fixed date");
+    }
+
+    @Test
+    void timeseries_dateRange_endDateIsFixedDate() {
+        var params = renderer.render(tsInterp()).params();
+        assertEquals(FIXED_DATE.toString(), params.get("end_date"),
+                "end_date should be the fixed clock date");
+    }
+
+    @Test
+    void timeseries_dateRange_sqlContainsBetweenClause() {
+        var sql = renderer.render(tsInterp()).sql();
+        assertTrue(sql.contains("cob_date between :start_date and :end_date"), sql);
+    }
+
+    @Test
+    void timeseries_dateRange_doesNotContainHardcodedDate() {
+        var sql = renderer.render(tsInterp()).sql();
+        // Dates must be in params, not in SQL text
+        assertFalse(sql.contains(FIXED_DATE.toString()),
+                "end date must not appear literally in SQL");
+        assertFalse(sql.contains(EXPECTED_START.toString()),
+                "start date must not appear literally in SQL");
+    }
+
+    // ── 12. Default limit is applied ───────────────────────────────────────────
+
+    @Test
+    void defaultLimit_appliedToGridRender() {
+        var result = renderer.render(gridInterp());
+        assertEquals(WhitelistedDemoSemanticSqlRenderer.DEFAULT_LIMIT,
+                result.params().get("limit"));
+    }
+
+    @Test
+    void defaultLimit_appliedToTimeseriesRender() {
+        var result = renderer.render(tsInterp());
+        assertEquals(WhitelistedDemoSemanticSqlRenderer.DEFAULT_LIMIT,
+                result.params().get("limit"));
+    }
+
+    // ── 13. Limit cap is applied ───────────────────────────────────────────────
+
+    @Test
+    void limitAboveMax_cappedAtMax() {
+        var cappedRenderer = WhitelistedDemoSemanticSqlRenderer.create(
+                DemoViewConfig.defaults(), FIXED_CLOCK, 999_999);
+        int limitInParams = (int) cappedRenderer.render(gridInterp()).params().get("limit");
+        assertEquals(WhitelistedDemoSemanticSqlRenderer.MAX_LIMIT, limitInParams,
+                "limit exceeding MAX_LIMIT must be capped");
+    }
+
+    @Test
+    void limitZero_throws() {
+        assertThrows(IllegalArgumentException.class, () ->
+                WhitelistedDemoSemanticSqlRenderer.create(DemoViewConfig.defaults(), FIXED_CLOCK, 0));
+    }
+
+    @Test
+    void limitNegative_throws() {
+        assertThrows(IllegalArgumentException.class, () ->
+                WhitelistedDemoSemanticSqlRenderer.create(DemoViewConfig.defaults(), FIXED_CLOCK, -1));
+    }
+
+    @Test
+    void customLimit_belowMax_appliedExactly() {
+        var r      = WhitelistedDemoSemanticSqlRenderer.create(DemoViewConfig.defaults(), FIXED_CLOCK, 100);
+        int actual = (int) r.render(gridInterp()).params().get("limit");
+        assertEquals(100, actual);
+    }
+
+    // ── 14. Rendered SQL never contains raw user-supplied text ─────────────────
+
+    @Test
+    void filterValues_notInSqlText_grid() {
+        var result = renderer.render(gridInterp());
+        assertFalse(result.sql().contains("CIB"),        "raw org value must not appear in SQL");
+        assertFalse(result.sql().contains("USD"),        "raw currency value must not appear in SQL");
+        assertFalse(result.sql().contains("2026-05-15"), "raw date value must not appear in SQL");
+    }
+
+    @Test
+    void filterValues_notInSqlText_timeseries() {
+        var result = renderer.render(tsInterp());
+        assertFalse(result.sql().contains("CIB"),   "raw org value must not appear in SQL");
+        assertFalse(result.sql().contains("rates"),
+                "raw risk_class value must not appear in SQL (only param name :risk_class should)");
+    }
+
+    // ── Security: injection attempt via filter value ───────────────────────────
+
+    @Test
+    void injectionAttempt_orgValue_notInSqlText() {
+        String injected = "CIB' OR 1=1 --";
+        var interp = new DemoSemanticQueryInterpretation(
+                "test", GRID_CONTRACT, "delta_exposure",
+                List.of("legal_entity"),
+                List.of(DemoSemanticFilter.eq("org", injected)),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.HIGH,
+                List.of());
+
+        var result = renderer.render(interp);
+
+        // SQL contains only the named placeholder
+        assertTrue(result.sql().contains(":org"), result.sql());
+        // Raw injection string is NOT in SQL text
+        assertFalse(result.sql().contains("OR 1=1"), result.sql());
+        assertFalse(result.sql().contains("--"),      result.sql());
+        // Raw value IS in params map (where it will be safely bound by JDBC)
+        assertEquals(injected, result.params().get("org"));
+    }
+
+    @Test
+    void injectionAttempt_measureNotSubstituted() {
+        // measure comes from the allowlist check — a bad measure name is rejected before SQL
+        assertThrows(DemoSemanticSqlRenderException.class, () ->
+                renderer.render(interpWithMeasure("delta_exposure; DROP TABLE users; --")));
+    }
+
+    // ── 15. Renderer requires no external services ─────────────────────────────
+
+    @Test
+    void renderer_createsWithDefaults_noExternalDeps() {
+        // createWithDefaults() uses real clock, but render is still pure string manipulation
+        assertDoesNotThrow(() -> WhitelistedDemoSemanticSqlRenderer.createWithDefaults());
+    }
+
+    @Test
+    void renderer_isInstanceOfInterface() {
+        assertInstanceOf(DemoSemanticSqlRenderer.class, renderer);
+    }
+
+    // ── Param map is unmodifiable ──────────────────────────────────────────────
+
+    @Test
+    void params_areUnmodifiable() {
+        var result = renderer.render(gridInterp());
+        assertThrows(UnsupportedOperationException.class,
+                () -> result.params().put("extra", "val"));
+    }
+
+    @Test
+    void groupBy_isUnmodifiable() {
+        var result = renderer.render(gridInterp());
+        assertThrows(UnsupportedOperationException.class,
+                () -> result.groupBy().add("extra"));
+    }
+
+    // ── Null guard ─────────────────────────────────────────────────────────────
+
+    @Test
+    void nullInterpretation_throws() {
+        assertThrows(NullPointerException.class, () -> renderer.render(null));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /** Standard exposure-grid interpretation matching the issue's required render example. */
+    private static DemoSemanticQueryInterpretation gridInterp() {
+        return new DemoSemanticQueryInterpretation(
+                "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15",
+                GRID_CONTRACT,
+                "delta_exposure",
+                List.of("legal_entity", "risk_class"),
+                List.of(
+                        DemoSemanticFilter.eq("org",      "CIB"),
+                        DemoSemanticFilter.eq("currency", "USD"),
+                        DemoSemanticFilter.eq("cob_date", "2026-05-15")),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.HIGH,
+                List.of());
+    }
+
+    /** Standard time-series interpretation matching the issue's required render example. */
+    private static DemoSemanticQueryInterpretation tsInterp() {
+        return new DemoSemanticQueryInterpretation(
+                "Show the last 30 days of rates DV01 by desk for CIB",
+                TS_CONTRACT,
+                "dv01",
+                List.of("desk"),
+                List.of(
+                        DemoSemanticFilter.eq("org",        "CIB"),
+                        DemoSemanticFilter.eq("risk_class", "rates"),
+                        DemoSemanticFilter.eq("date_range", "last_30_days")),
+                DemoSemanticOutputShape.TIMESERIES,
+                DemoSemanticInterpretationConfidence.HIGH,
+                List.of());
+    }
+
+    private static DemoSemanticQueryInterpretation interpWithContract(String contractId) {
+        return new DemoSemanticQueryInterpretation(
+                "test", contractId, "delta_exposure",
+                List.of("desk"), List.of(DemoSemanticFilter.eq("org", "CIB")),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.HIGH, List.of());
+    }
+
+    private static DemoSemanticQueryInterpretation interpWithMeasure(String measure) {
+        return new DemoSemanticQueryInterpretation(
+                "test", GRID_CONTRACT, measure,
+                List.of("desk"), List.of(DemoSemanticFilter.eq("org", "CIB")),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.HIGH, List.of());
+    }
+
+    private static DemoSemanticQueryInterpretation interpWithGroupBy(List<String> groupBy) {
+        return new DemoSemanticQueryInterpretation(
+                "test", GRID_CONTRACT, "delta_exposure",
+                groupBy, List.of(DemoSemanticFilter.eq("org", "CIB")),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.HIGH, List.of());
+    }
+
+    private static DemoSemanticQueryInterpretation interpWithExtraFilter(String name, String value) {
+        return new DemoSemanticQueryInterpretation(
+                "test", GRID_CONTRACT, "delta_exposure",
+                List.of("desk"),
+                List.of(DemoSemanticFilter.eq("org", "CIB"),
+                        DemoSemanticFilter.eq(name, value)),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.HIGH, List.of());
+    }
+
+    private static DemoSemanticQueryInterpretation unsupportedInterp() {
+        return new DemoSemanticQueryInterpretation(
+                "Show me everything", null, null,
+                List.of(), List.of(), DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.UNSUPPORTED,
+                List.of("Unsupported request"));
+    }
+
+    private static DemoSemanticQueryInterpretation ambiguousInterp() {
+        return new DemoSemanticQueryInterpretation(
+                "Show exposure", null, null,
+                List.of(), List.of(), DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.AMBIGUOUS,
+                List.of("Cannot determine measure"));
+    }
+}


### PR DESCRIPTION
## Closes

Closes #125

## Summary

Adds a whitelisted SQL template renderer for the two market-risk sensitivity demo query shapes.

**New files (6 + 1 updated):**

| Type | File | Purpose |
|---|---|---|
| record | `DemoViewConfig` | Operator-controlled view names; `defaults()` factory with safe placeholder names |
| record | `DemoSemanticRenderedSql` | SQL text + bind params map + rendering metadata |
| exception | `DemoSemanticSqlRenderException` | Unchecked; thrown on any allowlist failure |
| interface | `DemoSemanticSqlRenderer` | Single-method interface: `render(interpretation)` |
| class | `WhitelistedDemoSemanticSqlRenderer` | Allowlist-gated implementation with `Clock` injection |
| test | `DemoSemanticSqlRendererTest` | 52 focused unit tests |
| updated | `package-info.java` | Documents new entry points |

## Supported render paths

**Exposure grid:**
```sql
select legal_entity, risk_class, sum(delta_exposure) as delta_exposure
from demo.market_risk.v_sensitivity_exposure_demo
where org = :org and currency = :currency and cob_date = :cob_date
group by legal_entity, risk_class
order by legal_entity, risk_class
limit :limit
```
Params: `{org: "CIB", currency: "USD", cob_date: "2026-05-15", limit: 500}`

**Historical time-series:**
```sql
select cob_date, desk, sum(dv01) as dv01
from demo.market_risk.v_sensitivity_history_demo
where cob_date between :start_date and :end_date
  and org = :org
  and risk_class = :risk_class
group by cob_date, desk
order by cob_date, desk
limit :limit
```
Params: `{start_date: "2026-04-18", end_date: "2026-05-18", org: "CIB", risk_class: "rates", limit: 500}`

## Safety guarantees

- **Allowlists**: contracts, measures, dimensions, and filter names are each validated against explicit sets before any SQL is assembled
- **Bind parameters**: all filter values appear only as `:param_name` in SQL text; raw values held in the params map — injection attempts via filter values cannot reach SQL text (proven by test `injectionAttempt_orgValue_notInSqlText`)
- **Configured view names**: FROM clauses reference `DemoViewConfig` (operator-controlled), not user input
- **Clock injection**: `date_range=last_30_days` expansion uses an injected `Clock` for deterministic test assertions

## Tests run

```
./mvnw test -pl skadi-semantic -Dtest=DemoSemanticSqlRendererTest
Tests run: 52, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

./mvnw verify -pl skadi-semantic
Tests run: 724, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

## Guardrail statement

No query execution, Databricks calls, LLM integration, arbitrary SQL generation, or `skadi-sql-gateway` changes were introduced in this PR. The renderer is pure string assembly gated by explicit allowlists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)