### PR TITLE
fix: materialize demo semantic SQL safely for execution

### DIFF
--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlMaterializationException.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlMaterializationException.java
@@ -1,0 +1,23 @@
+package org.iceforge.skadi.semantic.demo;
+
+/**
+ * Thrown by {@link DemoSemanticSqlMaterializer} when a {@link DemoSemanticRenderedSql}
+ * cannot be safely materialized into final SQL text.
+ *
+ * <p>Common causes:
+ * <ul>
+ *   <li>A {@code :param_name} placeholder has no corresponding entry in the params map</li>
+ *   <li>A parameter value type is not supported (only String, Integer, Long, LocalDate,
+ *       and other Number subtypes are accepted)</li>
+ *   <li>A parameter value is {@code null}</li>
+ * </ul>
+ *
+ * <p>The message names the parameter involved but never includes raw SQL fragments
+ * or execution credentials.
+ */
+public final class DemoSemanticSqlMaterializationException extends RuntimeException {
+
+    public DemoSemanticSqlMaterializationException(String message) {
+        super(message);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlMaterializer.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlMaterializer.java
@@ -1,0 +1,114 @@
+package org.iceforge.skadi.semantic.demo;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Substitutes named bind-parameter placeholders in a {@link DemoSemanticRenderedSql}
+ * with safe SQL literals, producing final SQL text suitable for
+ * {@link org.iceforge.skadi.semantic.service.QueryExecutionRequest#sqlOnly}.
+ *
+ * <h2>Why this exists</h2>
+ * <p>{@code QueryExecutionRequest.sqlOnly()} carries only SQL text; there is no
+ * named-parameter carrier in the current execution seam. Rather than send unresolved
+ * {@code :param} placeholders to Databricks, the demo pipeline materializes them here
+ * using strict, demo-scoped rules before handing off to execution.
+ *
+ * <h2>Safety guarantees</h2>
+ * <ul>
+ *   <li><b>Only known params are substituted</b> — every {@code :word} token in the SQL
+ *       must appear in {@link DemoSemanticRenderedSql#params()}; any unrecognised token
+ *       throws {@link DemoSemanticSqlMaterializationException}.</li>
+ *   <li><b>String injection is neutralised</b> — string values are single-quoted and all
+ *       internal single-quotes are doubled ({@code '} → {@code ''}).</li>
+ *   <li><b>Numeric values are rendered without quotes</b> — only {@code Integer} and
+ *       {@code Long} (and other {@code Number}) values receive this treatment.</li>
+ *   <li><b>Date values</b> — {@link LocalDate} renders as {@code DATE 'yyyy-MM-dd'};
+ *       date strings stored as {@code String} (as produced by the renderer) render as
+ *       single-quoted strings, which Databricks SQL implicitly casts to date in context.</li>
+ *   <li><b>Identifiers are never substituted</b> — column names, table names, and SQL
+ *       keywords in the template come only from the whitelisted renderer; this class only
+ *       touches {@code :param} placeholders.</li>
+ * </ul>
+ *
+ * <h2>Supported param value types</h2>
+ * <ul>
+ *   <li>{@link String} → {@code 'escaped value'} (internal {@code '} doubled)</li>
+ *   <li>{@link Integer} / {@link Long} → bare numeric literal</li>
+ *   <li>{@link LocalDate} → {@code DATE 'yyyy-MM-dd'}</li>
+ *   <li>Other {@link Number} subtypes → bare numeric literal via {@code toString()}</li>
+ * </ul>
+ *
+ * <pre>{@code
+ * DemoSemanticRenderedSql rendered = renderer.render(interpretation);
+ * String finalSql = DemoSemanticSqlMaterializer.materialize(rendered);
+ * QueryExecutionRequest.sqlOnly(ctx, finalSql, CacheContract.none());
+ * }</pre>
+ */
+public final class DemoSemanticSqlMaterializer {
+
+    /** Matches any {@code :word} token (colon followed by one or more word characters). */
+    private static final Pattern NAMED_PARAM = Pattern.compile(":(\\w+)");
+
+    private DemoSemanticSqlMaterializer() {}
+
+    /**
+     * Materializes {@code rendered} by replacing all {@code :param_name} placeholders
+     * with safe SQL literals derived from {@link DemoSemanticRenderedSql#params()}.
+     *
+     * @param rendered the whitelisted rendered SQL with param map; must not be null
+     * @return final SQL text with all placeholders resolved; never null or blank
+     * @throws DemoSemanticSqlMaterializationException if any placeholder is not in the
+     *         params map, if a param value is null, or if a value type is unsupported
+     */
+    public static String materialize(DemoSemanticRenderedSql rendered) {
+        String              sql    = rendered.sql();
+        Map<String, Object> params = rendered.params();
+
+        Matcher      matcher = NAMED_PARAM.matcher(sql);
+        StringBuffer result  = new StringBuffer();
+
+        while (matcher.find()) {
+            String paramName = matcher.group(1);
+
+            if (!params.containsKey(paramName)) {
+                throw new DemoSemanticSqlMaterializationException(
+                        "No parameter value found for placeholder: :" + paramName);
+            }
+
+            Object value   = params.get(paramName);
+            String literal = toLiteral(paramName, value);
+            matcher.appendReplacement(result, Matcher.quoteReplacement(literal));
+        }
+
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    // ── Type-to-literal conversion ─────────────────────────────────────────────
+
+    private static String toLiteral(String paramName, Object value) {
+        if (value == null) {
+            throw new DemoSemanticSqlMaterializationException(
+                    "Parameter value is null for: " + paramName);
+        }
+        if (value instanceof String s) {
+            // Single-quote the value; double any internal single quotes to neutralise injection.
+            return "'" + s.replace("'", "''") + "'";
+        }
+        if (value instanceof Integer || value instanceof Long) {
+            return value.toString();
+        }
+        if (value instanceof LocalDate d) {
+            return "DATE '" + d + "'";
+        }
+        if (value instanceof Number n) {
+            return n.toString();
+        }
+        throw new DemoSemanticSqlMaterializationException(
+                "Unsupported parameter value type " + value.getClass().getSimpleName()
+                + " for parameter: " + paramName);
+    }
+}

--- a/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/package-info.java
+++ b/skadi-semantic/src/main/java/org/iceforge/skadi/semantic/demo/package-info.java
@@ -14,6 +14,7 @@
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticSqlRenderer} — SQL renderer interface</li>
  *   <li>{@link org.iceforge.skadi.semantic.demo.WhitelistedDemoSemanticSqlRenderer} — allowlist-gated SQL renderer</li>
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticRenderedSql} — rendered SQL with bind params</li>
+ *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticSqlMaterializer} — substitutes :params with safe literals for SQL-only execution</li>
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoViewConfig} — operator-controlled view name config</li>
  *   <li>{@link org.iceforge.skadi.semantic.demo.DemoSemanticQueryExecutionResponse} — full execution response</li>
  * </ul>

--- a/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlMaterializerTest.java
+++ b/skadi-semantic/src/test/java/org/iceforge/skadi/semantic/demo/DemoSemanticSqlMaterializerTest.java
@@ -1,0 +1,306 @@
+package org.iceforge.skadi.semantic.demo;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link DemoSemanticSqlMaterializer}.
+ *
+ * <p>No Spring context, no Databricks, no S3, no network.
+ */
+class DemoSemanticSqlMaterializerTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            LocalDate.of(2026, 5, 18).atStartOfDay(ZoneOffset.UTC).toInstant(),
+            ZoneOffset.UTC);
+
+    private static final String GRID_CONTRACT = "risk_sensitivity_exposure_grid";
+    private static final String TS_CONTRACT   = "risk_sensitivity_historical_timeseries";
+
+    // ── 1. Exposure-grid: no :params remain after materialization ─────────────
+
+    @Test
+    void exposureGrid_materializedSql_noOrgPlaceholder() {
+        var sql = materializeGrid();
+        assertFalse(sql.contains(":org"),      "materialized SQL must not contain :org");
+    }
+
+    @Test
+    void exposureGrid_materializedSql_noCurrencyPlaceholder() {
+        var sql = materializeGrid();
+        assertFalse(sql.contains(":currency"), "materialized SQL must not contain :currency");
+    }
+
+    @Test
+    void exposureGrid_materializedSql_noCobDatePlaceholder() {
+        var sql = materializeGrid();
+        assertFalse(sql.contains(":cob_date"), "materialized SQL must not contain :cob_date");
+    }
+
+    @Test
+    void exposureGrid_materializedSql_noLimitPlaceholder() {
+        var sql = materializeGrid();
+        assertFalse(sql.contains(":limit"),    "materialized SQL must not contain :limit");
+    }
+
+    // ── 2. Time-series: no :params remain after materialization ───────────────
+
+    @Test
+    void timeseries_materializedSql_noStartDatePlaceholder() {
+        var sql = materializeTimeseries();
+        assertFalse(sql.contains(":start_date"), sql);
+    }
+
+    @Test
+    void timeseries_materializedSql_noEndDatePlaceholder() {
+        var sql = materializeTimeseries();
+        assertFalse(sql.contains(":end_date"), sql);
+    }
+
+    @Test
+    void timeseries_materializedSql_noOrgPlaceholder() {
+        var sql = materializeTimeseries();
+        assertFalse(sql.contains(":org"), sql);
+    }
+
+    @Test
+    void timeseries_materializedSql_noRiskClassPlaceholder() {
+        var sql = materializeTimeseries();
+        assertFalse(sql.contains(":risk_class"), sql);
+    }
+
+    @Test
+    void timeseries_materializedSql_noLimitPlaceholder() {
+        var sql = materializeTimeseries();
+        assertFalse(sql.contains(":limit"), sql);
+    }
+
+    // ── 3. Expected safe literals in materialized exposure-grid SQL ───────────
+
+    @Test
+    void exposureGrid_materializedSql_containsCibLiteral() {
+        var sql = materializeGrid();
+        assertTrue(sql.contains("'CIB'"), "org=CIB must appear as quoted literal: " + sql);
+    }
+
+    @Test
+    void exposureGrid_materializedSql_containsUsdLiteral() {
+        var sql = materializeGrid();
+        assertTrue(sql.contains("'USD'"), "currency=USD must appear as quoted literal: " + sql);
+    }
+
+    @Test
+    void exposureGrid_materializedSql_containsDateLiteral() {
+        var sql = materializeGrid();
+        assertTrue(sql.contains("'2026-05-15'"), "cob_date must appear as quoted date: " + sql);
+    }
+
+    @Test
+    void exposureGrid_materializedSql_containsNumericLimit() {
+        var sql = materializeGrid();
+        assertTrue(sql.contains("limit 500"), "limit must appear as bare integer: " + sql);
+    }
+
+    // ── 4. Injection: single-quote in string value is doubled ─────────────────
+
+    @Test
+    void injection_singleQuoteInOrgValue_isDoubled() {
+        var rendered = renderedWithParams(
+                "select * from v where org = :org",
+                Map.of("org", "CIB' OR 1=1 --"));
+        var sql = DemoSemanticSqlMaterializer.materialize(rendered);
+
+        // After quote-doubling the single quote inside the value becomes '' within the string.
+        // The SQL parser sees one string literal containing "CIB' OR 1=1 --", not two strings
+        // with an OR clause between them.
+        assertTrue(sql.contains("'CIB'' OR 1=1 --'"), "injection value must be double-quoted: " + sql);
+        // The premature string-close form 'CIB' (which would let OR 1=1 escape into SQL)
+        // must not appear — the doubled '' prevents the string from ending early.
+        assertFalse(sql.contains("= 'CIB' OR"),
+                "unescaped injection break-out must not appear: " + sql);
+    }
+
+    @Test
+    void injection_doubleQuoteInString_isHandled() {
+        var rendered = renderedWithParams(
+                "select * from v where org = :org",
+                Map.of("org", "CIB\" test"));
+        var sql = DemoSemanticSqlMaterializer.materialize(rendered);
+        // Double-quotes are not SQL injection vectors in single-quoted strings
+        assertTrue(sql.contains("'CIB\" test'"), sql);
+    }
+
+    // ── 5. Unknown placeholder: throws ───────────────────────────────────────
+
+    @Test
+    void unknownPlaceholder_throwsMaterializationException() {
+        var rendered = renderedWithParams(
+                "select * from v where org = :unknown_param",
+                Map.of("org", "CIB"));
+        assertThrows(DemoSemanticSqlMaterializationException.class,
+                () -> DemoSemanticSqlMaterializer.materialize(rendered));
+    }
+
+    @Test
+    void unknownPlaceholder_exceptionMessageNamesParameter() {
+        var rendered = renderedWithParams(
+                "select * from v where org = :secret_param",
+                Map.of("org", "CIB"));
+        var ex = assertThrows(DemoSemanticSqlMaterializationException.class,
+                () -> DemoSemanticSqlMaterializer.materialize(rendered));
+        assertTrue(ex.getMessage().contains("secret_param"), ex.getMessage());
+    }
+
+    // ── 6. Missing param for declared placeholder: throws ─────────────────────
+
+    @Test
+    void missingParam_forDeclaredPlaceholder_throws() {
+        // SQL has :risk_class but params map only has :org
+        var rendered = renderedWithParams(
+                "select * from v where org = :org and risk_class = :risk_class",
+                Map.of("org", "CIB"));
+        assertThrows(DemoSemanticSqlMaterializationException.class,
+                () -> DemoSemanticSqlMaterializer.materialize(rendered));
+    }
+
+    // ── 7. Deterministic materialization ─────────────────────────────────────
+
+    @Test
+    void materialization_isDeterministic() {
+        var sql1 = materializeGrid();
+        var sql2 = materializeGrid();
+        assertEquals(sql1, sql2, "materialization must be deterministic");
+    }
+
+    @Test
+    void stringValues_alwaysSingleQuoted() {
+        var rendered = renderedWithParams(
+                ":org and :currency",
+                Map.of("org", "CIB", "currency", "USD"));
+        var sql = DemoSemanticSqlMaterializer.materialize(rendered);
+        assertEquals("'CIB' and 'USD'", sql);
+    }
+
+    @Test
+    void integerLimit_renderedWithoutQuotes() {
+        var rendered = renderedWithParams("limit :limit", Map.of("limit", 500));
+        assertEquals("limit 500", DemoSemanticSqlMaterializer.materialize(rendered));
+    }
+
+    @Test
+    void longValue_renderedWithoutQuotes() {
+        var rendered = renderedWithParams("limit :limit", Map.of("limit", 5000L));
+        assertEquals("limit 5000", DemoSemanticSqlMaterializer.materialize(rendered));
+    }
+
+    @Test
+    void localDateValue_renderedWithDatePrefix() {
+        var rendered = renderedWithParams(
+                "cob_date = :dt",
+                Map.of("dt", LocalDate.of(2026, 5, 15)));
+        assertEquals("cob_date = DATE '2026-05-15'",
+                DemoSemanticSqlMaterializer.materialize(rendered));
+    }
+
+    // ── 8. Unsupported param type: throws ─────────────────────────────────────
+
+    @Test
+    void unsupportedParamType_boolean_throws() {
+        var rendered = renderedWithParams(":flag", Map.of("flag", Boolean.TRUE));
+        var ex = assertThrows(DemoSemanticSqlMaterializationException.class,
+                () -> DemoSemanticSqlMaterializer.materialize(rendered));
+        assertTrue(ex.getMessage().contains("Boolean"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("flag"),    ex.getMessage());
+    }
+
+    @Test
+    void unsupportedParamType_list_throws() {
+        // Use a raw map to bypass type safety
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("val", List.of("a", "b"));
+        var rendered = renderedWithParams(":val", params);
+        assertThrows(DemoSemanticSqlMaterializationException.class,
+                () -> DemoSemanticSqlMaterializer.materialize(rendered));
+    }
+
+    // ── 9. Full renderer output can be materialized ───────────────────────────
+
+    @Test
+    void rendererOutput_gridInterpretation_fullyMaterializes() {
+        var rendered = renderGrid();
+        assertDoesNotThrow(() -> DemoSemanticSqlMaterializer.materialize(rendered));
+    }
+
+    @Test
+    void rendererOutput_timeseriesInterpretation_fullyMaterializes() {
+        var rendered = renderTimeseries();
+        assertDoesNotThrow(() -> DemoSemanticSqlMaterializer.materialize(rendered));
+    }
+
+    @Test
+    void rendererOutput_noPlaceholdersRemainAfterMaterialization() {
+        for (var rendered : List.of(renderGrid(), renderTimeseries())) {
+            var materialized = DemoSemanticSqlMaterializer.materialize(rendered);
+            assertFalse(materialized.contains(":"),
+                    "no colon-param placeholders should remain: " + materialized);
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /** Renders and materializes the exposure-grid example. */
+    private static String materializeGrid() {
+        return DemoSemanticSqlMaterializer.materialize(renderGrid());
+    }
+
+    /** Renders and materializes the time-series example. */
+    private static String materializeTimeseries() {
+        return DemoSemanticSqlMaterializer.materialize(renderTimeseries());
+    }
+
+    private static DemoSemanticRenderedSql renderGrid() {
+        var renderer = WhitelistedDemoSemanticSqlRenderer.create(DemoViewConfig.defaults(), FIXED_CLOCK);
+        return renderer.render(new DemoSemanticQueryInterpretation(
+                "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15",
+                GRID_CONTRACT, "delta_exposure",
+                List.of("legal_entity", "risk_class"),
+                List.of(
+                        DemoSemanticFilter.eq("org",      "CIB"),
+                        DemoSemanticFilter.eq("currency", "USD"),
+                        DemoSemanticFilter.eq("cob_date", "2026-05-15")),
+                DemoSemanticOutputShape.GRID,
+                DemoSemanticInterpretationConfidence.HIGH,
+                List.of()));
+    }
+
+    private static DemoSemanticRenderedSql renderTimeseries() {
+        var renderer = WhitelistedDemoSemanticSqlRenderer.create(DemoViewConfig.defaults(), FIXED_CLOCK);
+        return renderer.render(new DemoSemanticQueryInterpretation(
+                "Show the last 30 days of rates DV01 by desk for CIB",
+                TS_CONTRACT, "dv01",
+                List.of("desk"),
+                List.of(
+                        DemoSemanticFilter.eq("org",        "CIB"),
+                        DemoSemanticFilter.eq("risk_class", "rates"),
+                        DemoSemanticFilter.eq("date_range", "last_30_days")),
+                DemoSemanticOutputShape.TIMESERIES,
+                DemoSemanticInterpretationConfidence.HIGH,
+                List.of()));
+    }
+
+    /** Creates a minimal DemoSemanticRenderedSql with a given SQL string and params map. */
+    private static DemoSemanticRenderedSql renderedWithParams(String sql,
+                                                               Map<String, Object> params) {
+        return new DemoSemanticRenderedSql(
+                sql, params, GRID_CONTRACT, DemoSemanticOutputShape.GRID,
+                "delta_exposure", List.of("desk"), "demo.view");
+    }
+}

--- a/skadi-server/src/main/java/org/iceforge/skadi/semantic/DemoSemanticQueryExecutionFacade.java
+++ b/skadi-server/src/main/java/org/iceforge/skadi/semantic/DemoSemanticQueryExecutionFacade.java
@@ -11,6 +11,8 @@ import org.iceforge.skadi.semantic.demo.DemoSemanticQueryInterpretation;
 import org.iceforge.skadi.semantic.demo.DemoSemanticQueryRequest;
 import org.iceforge.skadi.semantic.demo.DemoSemanticRenderedSql;
 import org.iceforge.skadi.semantic.demo.DemoSemanticResultColumn;
+import org.iceforge.skadi.semantic.demo.DemoSemanticSqlMaterializationException;
+import org.iceforge.skadi.semantic.demo.DemoSemanticSqlMaterializer;
 import org.iceforge.skadi.semantic.demo.DemoSemanticSqlRenderException;
 import org.iceforge.skadi.semantic.demo.DemoSemanticSqlRenderer;
 import org.iceforge.skadi.semantic.demo.DemoViewConfig;
@@ -47,7 +49,11 @@ import java.util.Objects;
  *   <li>Render SQL via {@link DemoSemanticSqlRenderer} (which enforces its own allowlists).
  *       A {@link DemoSemanticSqlRenderException} is mapped to a safe denied response
  *       without calling the execution service.</li>
- *   <li>Execute the rendered SQL through the injected {@link QueryExecutionService}.</li>
+ *   <li>Materialize the rendered SQL: replace all {@code :param} placeholders with safe
+ *       SQL literals via {@link DemoSemanticSqlMaterializer}. This is necessary because
+ *       {@link org.iceforge.skadi.semantic.service.QueryExecutionRequest#sqlOnly} carries
+ *       only SQL text; there is no named-parameter carrier in the current execution seam.</li>
+ *   <li>Execute the materialized SQL through the injected {@link QueryExecutionService}.</li>
  *   <li>Map the {@link QueryExecutionResult} to a {@link DemoSemanticQueryExecutionResponse}.</li>
  * </ol>
  *
@@ -132,9 +138,21 @@ public final class DemoSemanticQueryExecutionFacade {
             return renderFailureResponse(request.text(), interpretation, ex.getMessage());
         }
 
+        // Step 3.5: Materialize :param placeholders into safe SQL literals.
+        // QueryExecutionRequest.sqlOnly() carries only SQL text; there is no named-parameter
+        // carrier in the current execution seam. The materializer applies strict quoting so
+        // that user-supplied filter values cannot escape the string context.
+        String materializedSql;
+        try {
+            materializedSql = DemoSemanticSqlMaterializer.materialize(rendered);
+        } catch (DemoSemanticSqlMaterializationException ex) {
+            return renderFailureResponse(request.text(), interpretation,
+                    "SQL materialization failed: " + ex.getMessage());
+        }
+
         // Step 4: Execute via the existing semantic execution seam
         var ctx     = new ExecutionContext(DEMO_PRINCIPAL, null, SOURCE_SYSTEM);
-        var execReq = QueryExecutionRequest.sqlOnly(ctx, rendered.sql(), CacheContract.none());
+        var execReq = QueryExecutionRequest.sqlOnly(ctx, materializedSql, CacheContract.none());
         var result  = executionService.execute(execReq);
 
         // Step 5: Map to response

--- a/skadi-server/src/test/java/org/iceforge/skadi/semantic/DemoSemanticQueryExecutionFacadeTest.java
+++ b/skadi-server/src/test/java/org/iceforge/skadi/semantic/DemoSemanticQueryExecutionFacadeTest.java
@@ -286,14 +286,14 @@ class DemoSemanticQueryExecutionFacadeTest {
     // ── 9. Default limit applies ───────────────────────────────────────────────
 
     @Test
-    void defaultLimit_appliedInRenderedSql() {
+    void defaultLimit_appliedInMaterializedSql() {
         var captured = new AtomicReference<String>();
         var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
         f.execute(req(GRID_PROMPT));
 
-        assertTrue(captured.get().contains("limit :limit"),
-                "rendered SQL must contain limit placeholder");
-        // Default limit (500) is in params, not in SQL text — verified via renderer tests
+        // After materialization :limit is replaced by the numeric literal
+        assertTrue(captured.get().contains("limit 500"),
+                "materialized SQL must contain numeric limit: " + captured.get());
     }
 
     // ── 10. Configured views are used ────────────────────────────────────────
@@ -372,6 +372,104 @@ class DemoSemanticQueryExecutionFacadeTest {
                     "execution service must be called for: " + prompt);
             assertEquals(ExecutionStatus.COMPLETED, resp.metadata().executionStatus(),
                     "execution should complete for: " + prompt);
+        }
+    }
+
+    // ── 14. Materialized SQL: no :param placeholders reach execution ──────────
+
+    @Test
+    void exposureGrid_submittedSql_hasNoOrgPlaceholder() {
+        var captured = new AtomicReference<String>();
+        var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+        f.execute(req(GRID_PROMPT));
+        assertFalse(captured.get().contains(":org"),
+                "submitted SQL must not contain :org — found: " + captured.get());
+    }
+
+    @Test
+    void exposureGrid_submittedSql_hasNoCurrencyPlaceholder() {
+        var captured = new AtomicReference<String>();
+        var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+        f.execute(req(GRID_PROMPT));
+        assertFalse(captured.get().contains(":currency"),      captured.get());
+    }
+
+    @Test
+    void exposureGrid_submittedSql_hasNoCobDatePlaceholder() {
+        var captured = new AtomicReference<String>();
+        var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+        f.execute(req(GRID_PROMPT));
+        assertFalse(captured.get().contains(":cob_date"),      captured.get());
+    }
+
+    @Test
+    void exposureGrid_submittedSql_hasNoLimitPlaceholder() {
+        var captured = new AtomicReference<String>();
+        var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+        f.execute(req(GRID_PROMPT));
+        assertFalse(captured.get().contains(":limit"),         captured.get());
+    }
+
+    @Test
+    void timeseries_submittedSql_hasNoStartDatePlaceholder() {
+        var captured = new AtomicReference<String>();
+        var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+        f.execute(req(TS_PROMPT));
+        assertFalse(captured.get().contains(":start_date"),    captured.get());
+    }
+
+    @Test
+    void timeseries_submittedSql_hasNoEndDatePlaceholder() {
+        var captured = new AtomicReference<String>();
+        var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+        f.execute(req(TS_PROMPT));
+        assertFalse(captured.get().contains(":end_date"),      captured.get());
+    }
+
+    @Test
+    void timeseries_submittedSql_hasNoRiskClassPlaceholder() {
+        var captured = new AtomicReference<String>();
+        var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+        f.execute(req(TS_PROMPT));
+        assertFalse(captured.get().contains(":risk_class"),    captured.get());
+    }
+
+    @Test
+    void exposureGrid_submittedSql_containsLiteralCib() {
+        var captured = new AtomicReference<String>();
+        var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+        f.execute(req(GRID_PROMPT));
+        assertTrue(captured.get().contains("'CIB'"),
+                "submitted SQL must contain quoted literal 'CIB'");
+    }
+
+    @Test
+    void exposureGrid_submittedSql_containsLiteralUsd() {
+        var captured = new AtomicReference<String>();
+        var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+        f.execute(req(GRID_PROMPT));
+        assertTrue(captured.get().contains("'USD'"),
+                "submitted SQL must contain quoted literal 'USD'");
+    }
+
+    @Test
+    void allSixDemoPrompts_submittedSqlHasNoRemainingPlaceholders() {
+        String[] prompts = {
+            "Show USD delta exposure by legal entity and risk class for CIB on 2026-05-15",
+            "Show the last 30 days of rates DV01 by desk for CIB",
+            "Show vega exposure by risk factor for CIB on 2026-05-15",
+            "Show gamma exposure by desk and currency for CIB on 2026-05-15",
+            "Show delta exposure by desk for CIB on 2026-05-15",
+            "Show rates DV01 history by desk for CIB over the last 30 days"
+        };
+        for (String prompt : prompts) {
+            var captured = new AtomicReference<String>();
+            var f = facadeWith(req -> { captured.set(req.sql()); return completed(req); });
+            f.execute(req(prompt));
+            assertNotNull(captured.get(), "SQL must be captured for: " + prompt);
+            assertFalse(captured.get().contains(":"),
+                    "submitted SQL must contain no colon-param placeholders for: "
+                    + prompt + " — got: " + captured.get());
         }
     }
 


### PR DESCRIPTION
## Fixes PR #132 (issue #126)

### Problem

`QueryExecutionRequest.sqlOnly()` carries only SQL text — no named-parameter carrier exists in the current execution seam. The demo endpoint was sending unresolved `:org`, `:currency`, `:cob_date`, `:start_date`, `:end_date`, `:limit` placeholders to the execution service, which would fail against Databricks.

### Fix

Adds `DemoSemanticSqlMaterializer` (`skadi-semantic`) that substitutes all `:param_name` placeholders with safe SQL literals before `QueryExecutionRequest.sqlOnly()` is called.

**Supported types:**
| Value type | Rendered as |
|---|---|
| `String` | `'single-quoted with '' doubling'` |
| `Integer` / `Long` | bare numeric literal (`500`) |
| `LocalDate` | `DATE 'yyyy-MM-dd'` |
| Other `Number` | `toString()` |
| Unknown type | throws `DemoSemanticSqlMaterializationException` |
| Missing param | throws `DemoSemanticSqlMaterializationException` |

**Injection safety:** single quotes in string values are doubled — `"CIB' OR 1=1 --"` materializes as `'CIB'' OR 1=1 --'`, a valid SQL string literal. The injection content cannot break out of the string context.

### Pipeline (updated `DemoSemanticQueryExecutionFacade`)

```
interpret → isExecutable? → render (allowlists) → materialize :params → execute → map result
```

Materialization failures are mapped to the same safe denied response as render failures — no SQL is sent to execution.

### Files changed

| Module | File | Change |
|---|---|---|
| `skadi-semantic` | `DemoSemanticSqlMaterializationException` | New |
| `skadi-semantic` | `DemoSemanticSqlMaterializer` | New |
| `skadi-semantic` | `DemoSemanticSqlMaterializerTest` | 28 new tests |
| `skadi-semantic` | `package-info.java` | Updated |
| `skadi-server` | `DemoSemanticQueryExecutionFacade` | Add materialization step |
| `skadi-server` | `DemoSemanticQueryExecutionFacadeTest` | 11 new tests |

### Tests run

```
./mvnw verify -pl skadi-semantic,skadi-server -am

skadi-semantic: Tests run: 752, Failures: 0, Errors: 0 — BUILD SUCCESS
skadi-server:   Tests run: 294, Failures: 0, Errors: 0 — BUILD SUCCESS
```

Materializer tests include:
- No `:param` placeholders remain after materialization (grid + timeseries)
- Expected literal values appear in materialized SQL (`'CIB'`, `'USD'`, `'2026-05-15'`, `limit 500`)
- Injection with `"CIB' OR 1=1 --"` → `'CIB'' OR 1=1 --'` (safe string literal)
- Unknown placeholder → throws
- Missing param → throws
- Unsupported type (`Boolean`, `List`) → throws
- LocalDate → `DATE '...'`
- Deterministic output

Facade tests verify no `:param` placeholders reach the execution service for all 6 demo prompts.

### Note

> Because `QueryExecutionRequest.sqlOnly()` currently has no bind-parameter carrier, the demo endpoint performs a narrow demo-scoped safe SQL materialization step after whitelist rendering and before execution. This is not a general SQL planner or parameter framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)